### PR TITLE
fix: do not parse hints as parameters

### DIFF
--- a/statement_parser.go
+++ b/statement_parser.go
@@ -226,8 +226,9 @@ func findParams(sql string) ([]string, error) {
 				lastCharWasEscapeChar = false
 			}
 		} else {
-			// We are not in a quoted string.
-			if c == paramPrefix && len(runes) > index+1 && !unicode.IsSpace(runes[index+1]) {
+			// We are not in a quoted string. It's a parameter if it is an '@' followed by a letter or an underscore.
+			// See https://cloud.google.com/spanner/docs/lexical#identifiers for identifier rules.
+			if c == paramPrefix && len(runes) > index+1 && (unicode.IsLetter(runes[index+1]) || runes[index+1] == '_') {
 				index++
 				startIndex := index
 				for index < len(runes) {

--- a/statement_parser_test.go
+++ b/statement_parser_test.go
@@ -495,6 +495,14 @@ func TestFindParams(t *testing.T) {
 			input: "INSERT INTO Foo (Col1, Col2, Col3) VALUES (@param1, @param2, @param3)",
 			want:  []string{"param1", "param2", "param3"},
 		},
+		{
+			input: "SELECT * FROM PersonsTable@{FORCE_INDEX=`my_index`} WHERE id=@id AND name=@name",
+			want:  []string{"id", "name"},
+		},
+		{
+			input: "SELECT * FROM PersonsTable @{FORCE_INDEX=my_index} WHERE id=@id AND name=@name",
+			want:  []string{"id", "name"},
+		},
 	}
 	for _, tc := range tests {
 		sql, err := removeCommentsAndTrim(tc.input)


### PR DESCRIPTION
Table hints and other hints in the middle of a SQL string would be seen as a named
parameter instead of a hint, which caused the statement parser to return the wrong
number of parameters in a SQL string.