### PR TITLE
fix: allow users to specify custom credentials

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -42,6 +42,13 @@ const userAgent = "go-sql-spanner/0.1"
 // 1. (Optional) Host: The host name and port number to connect to.
 // 2. Database name: The database name to connect to in the format `projects/my-project/instances/my-instance/databases/my-database`
 // 3. (Optional) Parameters: One or more parameters in the format `name=value`. Multiple entries are separated by `;`.
+//    The supported parameters are:
+//    - credentials: File name for the credentials to use. The connection will use the default credentials of the
+//                   environment if no credentials file is specified in the connection string.
+//    - usePlainText: Boolean that indicates whether the connection should use plain text communication or not. Set this
+//                    to true to connect to local mock servers that do not use SSL.
+//    - retryAbortsInternally: Boolean that indicates whether the connection should automatically retry aborted errors.
+//                             The default is true.
 // Example: `localhost:9010/projects/test-project/instances/test-instance/databases/test-database;usePlainText=true`
 var dsnRegExp = regexp.MustCompile("((?P<HOSTGROUP>[\\w.-]+(?:\\.[\\w\\.-]+)*[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+)/)?projects/(?P<PROJECTGROUP>(([a-z]|[-.:]|[0-9])+|(DEFAULT_PROJECT_ID)))(/instances/(?P<INSTANCEGROUP>([a-z]|[-]|[0-9])+)(/databases/(?P<DATABASEGROUP>([a-z]|[-]|[_]|[0-9])+))?)?(([\\?|;])(?P<PARAMSGROUP>.*))?")
 
@@ -149,6 +156,9 @@ func newConnector(d *Driver, dsn string) (*connector, error) {
 	opts := make([]option.ClientOption, 0)
 	if connectorConfig.host != "" {
 		opts = append(opts, option.WithEndpoint(connectorConfig.host))
+	}
+	if strval, ok := connectorConfig.params["credentials"]; ok {
+		opts = append(opts, option.WithCredentialsFile(strval))
 	}
 	if strval, ok := connectorConfig.params["useplaintext"]; ok {
 		if val, err := strconv.ParseBool(strval); err == nil && val {


### PR DESCRIPTION
The connection string did not extract and use any credentials that the user had set
in the connection string.