### PR TITLE
driver: Enable/respect driver.Valuer interface

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -673,6 +673,10 @@ func (c *conn) CheckNamedValue(value *driver.NamedValue) error {
 	if value == nil {
 		return nil
 	}
+	if valuer, ok := value.Value.(driver.Valuer); ok {
+		_, err := valuer.Value()
+		return err
+	}
 	switch t := value.Value.(type) {
 	default:
 		// Default is to fail, unless it is one of the following supported types.


### PR DESCRIPTION
This extends `CheckNamedValue` to respect the `driver.Valuer` interface.

note: I realize this repository does not accept direct contributions and I am opening this as a nudge/suggestion.

Fixes #135 