### PR TITLE
chore(main): Enable release-trigger bot for triggering release job

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,2 @@
+enabled: true
+multiScmName: go-sql-spanner


### PR DESCRIPTION
Changes made in accordance with this [doc](https://docs.google.com/document/d/1TBFAk5fvfiGkjn1jxAiWq_0Bk66SVQSy7jpR-tMY9GY/edit?resourcekey=0-oMKo4qoXb5rR-lVWWex7oQ#).
A common [build file](https://critique.corp.google.com/cl/533065353), shared by all the Go split repos, is created for the release job.