### PR TITLE
fix: initalize the connectors map to avoid nil pointer exception

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -177,6 +177,9 @@ type connector struct {
 func newConnector(d *Driver, dsn string) (*connector, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.connectors == nil {
+		d.connectors = make(map[string]*connector)
+	}
 	if c, ok := d.connectors[dsn]; ok {
 		return c, nil
 	}


### PR DESCRIPTION
Fixes: https://github.com/googleapis/go-sql-spanner/issues/154