### PR TITLE
feat: support of uint for gorm.Model 

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -723,7 +723,6 @@ func checkIsValidType(v driver.Value) bool {
 	default:
 		return false
 	case nil:
-	case uint:
 	case sql.NullInt64:
 	case sql.NullTime:
 	case sql.NullString:
@@ -738,6 +737,10 @@ func checkIsValidType(v driver.Value) bool {
 	case []*string:
 	case []byte:
 	case [][]byte:
+	case uint:
+	case []uint:
+	case *uint:
+	case *[]uint:
 	case int:
 	case []int:
 	case int64:

--- a/driver.go
+++ b/driver.go
@@ -723,6 +723,7 @@ func checkIsValidType(v driver.Value) bool {
 	default:
 		return false
 	case nil:
+	case uint:
 	case sql.NullInt64:
 	case sql.NullTime:
 	case sql.NullString:

--- a/stmt.go
+++ b/stmt.go
@@ -79,10 +79,6 @@ func prepareSpannerStmt(q string, args []driver.NamedValue) (spanner.Statement, 
 			name = names[i]
 		}
 		ss.Params[name] = v.Value
-		// check if value is uint change it to int64
-		if _, ok := v.Value.(uint); ok {
-			ss.Params[name] = int64(v.Value.(uint))
-		}
 	}
 	return ss, nil
 }

--- a/stmt.go
+++ b/stmt.go
@@ -79,6 +79,10 @@ func prepareSpannerStmt(q string, args []driver.NamedValue) (spanner.Statement, 
 			name = names[i]
 		}
 		ss.Params[name] = v.Value
+		// check if value is uint change it to int64
+		if _, ok := v.Value.(uint); ok {
+			ss.Params[name] = int64(v.Value.(uint))
+		}
 	}
 	return ss, nil
 }


### PR DESCRIPTION
https://gorm.io/docs/models.html#gorm-Model declares field ID type uint for gorm, this PR will enable use of uint datatype with spanner driver