### PR TITLE
docs: clarify postgresql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ $ gcloud beta emulators spanner start
 $ export SPANNER_EMULATOR_HOST=localhost:9010
 ```
 
+## Spanner PostgreSQL Interface
+
+This driver works specifically with the Spanner GoogleSQL dialect. For the
+Spanner PostgreSQL dialect, Go's
+[database/sql](https://golang.org/pkg/database/sql/) package can be used
+directly after setting up the
+[PGAdapter](https://cloud.google.com/spanner/docs/pgadapter).
+
 ## Troubleshooting
 
 The driver will retry any Aborted error that is returned by Cloud Spanner

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -17,10 +17,6 @@ Partition Reads
 ~~~~~~~
 Partition Reads can be done by unwrapping the Spanner-specific `SpannerConn` interface and doing the parition reads using that interface.
 
-PostgreSQL
-~~~~~~~
-Spanner databases that use the PostgreSQL dialect are not yet supported.
-
 Backups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Backups are not supported by this driver. Use the [Cloud Spanner Go client library](https://github.com/googleapis/google-cloud-go/tree/main/spanner) to manage backups programmatically.


### PR DESCRIPTION
Clarify that this driver is for GoogleSQL support and that for the Spanner PostgreSQL Interface, the Go `database/sql` package can be used directly once PGAdapter is setup.