### PR TITLE
fix: support uint query params

### DIFF
--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -478,7 +478,7 @@ func TestQueryWithAllTypes(t *testing.T) {
 		true,
 		"test",
 		[]byte("testbytes"),
-		int64(5),
+		uint(5),
 		3.14,
 		numeric("6.626"),
 		civil.Date{Year: 2021, Month: 7, Day: 21},

--- a/stmt.go
+++ b/stmt.go
@@ -15,9 +15,10 @@
 package spannerdriver
 
 import (
-	"cloud.google.com/go/spanner"
 	"context"
 	"database/sql/driver"
+
+	"cloud.google.com/go/spanner"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )


### PR DESCRIPTION
The driver did accept query parameters of type `uint`, but the underlying Spanner client would not accept these. `uint` query parameters therefore first need to be converted to `int64` and then sent to the Spanner client.