### PR TITLE
fix: []*int and []*uint

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -768,10 +768,12 @@ func checkIsValidType(v driver.Value) bool {
 	case []uint:
 	case *uint:
 	case []*uint:
+	case *[]uint:
 	case int:
 	case []int:
 	case *int:
 	case []*int:
+	case *[]int:
 	case int64:
 	case []int64:
 	case spanner.NullInt64:

--- a/driver.go
+++ b/driver.go
@@ -767,11 +767,11 @@ func checkIsValidType(v driver.Value) bool {
 	case uint:
 	case []uint:
 	case *uint:
-	case *[]uint:
+	case []*uint:
 	case int:
 	case []int:
 	case *int:
-	case *[]int:
+	case []*int:
 	case int64:
 	case []int64:
 	case spanner.NullInt64:

--- a/integration_test.go
+++ b/integration_test.go
@@ -435,17 +435,19 @@ func TestTypeRoundtrip(t *testing.T) {
 		{in: []*string{pointerTo("hello")}, scan: pointerTo([]spanner.NullString{})},
 		// []byte variants
 		{in: []byte{1, 2, 3}},
-		{in: [][]byte{[]byte{1, 2, 3}}},
+		{in: [][]byte{{1, 2, 3}}},
 		// uint, *uint variants
 		{in: uint(197)},
 		{in: []uint{197}, scan: pointerTo([]spanner.NullInt64{})},
 		{in: pointerTo(uint(197))},
 		{in: []*uint{pointerTo(uint(197))}, scan: pointerTo([]spanner.NullInt64{})},
+		{in: pointerTo([]uint{197}), scan: pointerTo([]spanner.NullInt64{})},
 		// int, *int variants
 		{in: int(197)},
 		{in: []int{197}, scan: pointerTo([]spanner.NullInt64{})},
 		{in: pointerTo(int(197))},
 		{in: []*int{pointerTo(197)}, scan: pointerTo([]spanner.NullInt64{})},
+		{in: pointerTo([]int{197}), scan: pointerTo([]spanner.NullInt64{})},
 		// int64, *int64 variants
 		{in: int64(197)},
 		{in: []int64{}, scan: pointerTo([]spanner.NullInt64{})},

--- a/stmt.go
+++ b/stmt.go
@@ -114,30 +114,34 @@ func convertParam(v driver.Value) driver.Value {
 		}
 		vi := int64(*v)
 		return &vi
-	case *[]int:
-		if v == nil {
-			return (*[]int64)(nil)
+	case []*int:
+		res := make([]*int64, len(v))
+		for i, val := range v {
+			if val == nil {
+				res[i] = nil
+			} else {
+				z := int64(*val)
+				res[i] = &z
+			}
 		}
-		res := make([]int64, len(*v))
-		for i, val := range *v {
-			res[i] = int64(val)
-		}
-		return &res
+		return res
 	case *uint:
 		if v == nil {
 			return (*int64)(nil)
 		}
 		vi := int64(*v)
 		return &vi
-	case *[]uint:
-		if v == nil {
-			return (*[]int64)(nil)
+	case []*uint:
+		res := make([]*int64, len(v))
+		for i, val := range v {
+			if val == nil {
+				res[i] = nil
+			} else {
+				z := int64(*val)
+				res[i] = &z
+			}
 		}
-		res := make([]int64, len(*v))
-		for i, val := range *v {
-			res[i] = int64(val)
-		}
-		return &res
+		return res
 	}
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -95,6 +95,9 @@ func convertParam(v driver.Value) driver.Value {
 	case int:
 		return int64(v)
 	case []int:
+		if v == nil {
+			return []int64(nil)
+		}
 		res := make([]int64, len(v))
 		for i, val := range v {
 			res[i] = int64(val)
@@ -103,6 +106,9 @@ func convertParam(v driver.Value) driver.Value {
 	case uint:
 		return int64(v)
 	case []uint:
+		if v == nil {
+			return []int64(nil)
+		}
 		res := make([]int64, len(v))
 		for i, val := range v {
 			res[i] = int64(val)
@@ -115,6 +121,9 @@ func convertParam(v driver.Value) driver.Value {
 		vi := int64(*v)
 		return &vi
 	case []*int:
+		if v == nil {
+			return []*int64(nil)
+		}
 		res := make([]*int64, len(v))
 		for i, val := range v {
 			if val == nil {
@@ -125,6 +134,15 @@ func convertParam(v driver.Value) driver.Value {
 			}
 		}
 		return res
+	case *[]int:
+		if v == nil {
+			return []int64(nil)
+		}
+		res := make([]int64, len(*v))
+		for i, val := range *v {
+			res[i] = int64(val)
+		}
+		return res
 	case *uint:
 		if v == nil {
 			return (*int64)(nil)
@@ -132,6 +150,9 @@ func convertParam(v driver.Value) driver.Value {
 		vi := int64(*v)
 		return &vi
 	case []*uint:
+		if v == nil {
+			return []*int64(nil)
+		}
 		res := make([]*int64, len(v))
 		for i, val := range v {
 			if val == nil {
@@ -140,6 +161,15 @@ func convertParam(v driver.Value) driver.Value {
 				z := int64(*val)
 				res[i] = &z
 			}
+		}
+		return res
+	case *[]uint:
+		if v == nil {
+			return []int64(nil)
+		}
+		res := make([]int64, len(*v))
+		for i, val := range *v {
+			res[i] = int64(val)
 		}
 		return res
 	}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestConvertParam(t *testing.T) {
 	check := func(in, want driver.Value) {
+		t.Helper()
 		got := convertParam(in)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("in:%#v want:%#v got:%#v", in, want, got)
@@ -29,16 +30,20 @@ func TestConvertParam(t *testing.T) {
 	}
 
 	check(uint(197), int64(197))
-	check(pointerTo[uint](197), pointerTo[int64](197))
+	check(pointerTo(uint(197)), pointerTo(int64(197)))
 	check((*uint)(nil), (*int64)(nil))
 
 	check([]uint{197}, []int64{197})
-	check(pointerTo[[]uint]([]uint{197}), pointerTo[[]int64]([]int64{197}))
-	check((*[]uint)(nil), (*[]int64)(nil))
+	check(pointerTo([]uint{197}), []int64{197})
+	check([]*uint{pointerTo(uint(197))}, []*int64{pointerTo(int64(197))})
+	check(([]*uint)(nil), ([]*int64)(nil))
+	check((*[]uint)(nil), ([]int64)(nil))
 
 	check([]int{197}, []int64{197})
-	check(pointerTo[[]int]([]int{197}), pointerTo[[]int64]([]int64{197}))
-	check((*[]int)(nil), (*[]int64)(nil))
+	check([]*int{pointerTo(int(197))}, []*int64{pointerTo(int64(197))})
+	check(pointerTo([]int{197}), []int64{197})
+	check(([]*int)(nil), ([]*int64)(nil))
+	check((*[]int)(nil), ([]int64)(nil))
 }
 
 func pointerTo[T any](v T) *T { return &v }


### PR DESCRIPTION
The types were mistyped as *[]uint and *[]int. Also adds an exhaustive test to all types listed in checkIsValidType.

It would be possible to support `*[]uint` as well, however, I'm not sure how useful it is.
