### PR TITLE
fix: avoid session leak on transaction retry (#300)

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -246,6 +246,9 @@ func (tx *readWriteTransaction) runWithRetry(ctx context.Context, f func(ctx con
 // retry retries the entire read/write transaction on a new Spanner transaction.
 // It will return ErrAbortedDueToConcurrentModification if the retry fails.
 func (tx *readWriteTransaction) retry(ctx context.Context) (err error) {
+	if tx.rwTx != nil {
+		tx.rwTx.Rollback(tx.ctx)
+	}
 	tx.rwTx, err = spanner.NewReadWriteStmtBasedTransaction(ctx, tx.client)
 	if err != nil {
 		return err


### PR DESCRIPTION
When `(*readWriteTransaction).retry()` is used, there is already an existing pending (errored) transaction. It gets overwritten with the new transaction object without closing the old one.

This change causes the old transaction to be closed (rollback'd) before the new one overwrites it, thus avoiding a potentially large session leak.