### PR TITLE
fix: autoremove container in examples

### DIFF
--- a/examples/emulator_runner.go
+++ b/examples/emulator_runner.go
@@ -93,6 +93,7 @@ func startEmulator() error {
 		Image:        "gcr.io/cloud-spanner-emulator/emulator",
 		ExposedPorts: nat.PortSet{"9010": {}},
 	}, &container.HostConfig{
+		AutoRemove:   true,
 		PortBindings: map[nat.Port][]nat.PortBinding{"9010": {{HostIP: "0.0.0.0", HostPort: "9010"}}},
 	}, nil, nil, "")
 	if err != nil {


### PR DESCRIPTION
When running the examples they leave unnecessary containers hanging
around. Add AutoRemove: true, to automatically remove them.
