### PR TITLE
feat: add method for getting batched statements

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -760,12 +761,10 @@ func (c *conn) InDMLBatch() bool {
 }
 
 func (c *conn) GetBatchedStatements() []spanner.Statement {
-	if c.batch == nil {
+	if c.batch == nil || c.batch.statements == nil {
 		return []spanner.Statement{}
 	}
-	res := make([]spanner.Statement, len(c.batch.statements))
-	copy(res, c.batch.statements)
-	return res
+	return slices.Clone(c.batch.statements)
 }
 
 func (c *conn) inBatch() bool {

--- a/driver.go
+++ b/driver.go
@@ -535,6 +535,10 @@ type SpannerConn interface {
 	InDDLBatch() bool
 	// InDMLBatch returns true if the connection is currently in a DML batch.
 	InDMLBatch() bool
+	// GetBatchedStatements returns a copy of the statements that are currently
+	// buffered to be executed as a DML or DDL batch. It returns an empty slice
+	// if no batch is active, or if there are no statements buffered.
+	GetBatchedStatements() []spanner.Statement
 
 	// RetryAbortsInternally returns true if the connection automatically
 	// retries all aborted transactions.
@@ -753,6 +757,15 @@ func (c *conn) InDDLBatch() bool {
 
 func (c *conn) InDMLBatch() bool {
 	return (c.batch != nil && c.batch.tp == dml) || (c.inReadWriteTransaction() && c.tx.(*readWriteTransaction).batch != nil)
+}
+
+func (c *conn) GetBatchedStatements() []spanner.Statement {
+	if c.batch == nil {
+		return []spanner.Statement{}
+	}
+	res := make([]spanner.Statement, len(c.batch.statements))
+	copy(res, c.batch.statements)
+	return res
 }
 
 func (c *conn) inBatch() bool {

--- a/driver_test.go
+++ b/driver_test.go
@@ -17,6 +17,7 @@ package spannerdriver
 import (
 	"context"
 	"database/sql/driver"
+	"reflect"
 	"testing"
 	"time"
 
@@ -421,6 +422,52 @@ func TestConn_NonDmlStatementsInDmlBatch(t *testing.T) {
 	// Executing a single query during a DML batch is allowed.
 	if _, err := c.QueryContext(ctx, "SELECT * FROM Foo", []driver.NamedValue{}); err != nil {
 		t.Fatalf("executing query failed: %v", err)
+	}
+}
+
+func TestConn_GetBatchedStatements(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := &conn{}
+	if !reflect.DeepEqual(c.GetBatchedStatements(), []spanner.Statement{}) {
+		t.Fatal("conn should return an empty slice when no batch is active")
+	}
+	if err := c.StartBatchDDL(); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(c.GetBatchedStatements(), []spanner.Statement{}) {
+		t.Fatal("conn should return an empty slice when a batch contains no statements")
+	}
+	if _, err := c.ExecContext(ctx, "create table table1", []driver.NamedValue{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ExecContext(ctx, "create table table2", []driver.NamedValue{}); err != nil {
+		t.Fatal(err)
+	}
+	batchedStatements := c.GetBatchedStatements()
+	if !reflect.DeepEqual([]spanner.Statement{
+		{SQL: "create table table1", Params: map[string]interface{}{}},
+		{SQL: "create table table2", Params: map[string]interface{}{}},
+	}, batchedStatements) {
+		t.Errorf("unexpected batched statements: %v", batchedStatements)
+	}
+
+	// Changing the returned slice does not change the batched statements.
+	batchedStatements[0] = spanner.Statement{SQL: "drop table table1"}
+	batchedStatements2 := c.GetBatchedStatements()
+	if !reflect.DeepEqual([]spanner.Statement{
+		{SQL: "create table table1", Params: map[string]interface{}{}},
+		{SQL: "create table table2", Params: map[string]interface{}{}},
+	}, batchedStatements2) {
+		t.Errorf("unexpected batched statements: %v", batchedStatements2)
+	}
+
+	if err := c.AbortBatch(); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(c.GetBatchedStatements(), []spanner.Statement{}) {
+		t.Fatal("conn should return an empty slice when no batch is active")
 	}
 }
 


### PR DESCRIPTION
Adds a GetBatchedStatements function that returns the currently buffered statements that will be executed if RunBatch is called. This gives applications the possibility of inspecting the list of buffered statements before actually executing them.