### PR TITLE
docs: add missing conn.Close() calls

### DIFF
--- a/examples/ddl-batches/main.go
+++ b/examples/ddl-batches/main.go
@@ -50,6 +50,7 @@ func ddlBatches(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get connection: %v", err)
 	}
+	defer conn.Close()
 	// Start a DDL batch on the connection.
 	if _, err := conn.ExecContext(ctx, "START BATCH DDL"); err != nil {
 		return fmt.Errorf("START BATCH DDL failed: %v", err)

--- a/examples/dml-batches/main.go
+++ b/examples/dml-batches/main.go
@@ -89,6 +89,7 @@ func dmlBatch(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get connection: %v", err)
 	}
+	defer conn.Close()
 	if err := conn.Raw(func(driverConn interface{}) error {
 		return driverConn.(spannerdriver.SpannerConn).StartBatchDML()
 	}); err != nil {

--- a/examples/mutations/main.go
+++ b/examples/mutations/main.go
@@ -44,6 +44,7 @@ func mutations(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	// Mutations can be written outside an explicit transaction using SpannerConn#Apply.
 	var commitTimestamp time.Time

--- a/examples/partitioned-dml/main.go
+++ b/examples/partitioned-dml/main.go
@@ -43,6 +43,7 @@ func partitionedDml(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get a connection: %v", err)
 	}
+	defer conn.Close()
 	if err := conn.Raw(func(driverConn interface{}) error {
 		_, err := driverConn.(spannerdriver.SpannerConn).Apply(ctx, []*spanner.Mutation{
 			spanner.InsertOrUpdateMap("Singers", map[string]interface{}{"SingerId": 1, "Name": "Singer 1"}),

--- a/examples/stale-reads/main.go
+++ b/examples/stale-reads/main.go
@@ -65,6 +65,7 @@ func staleReads(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET READ_ONLY_STALENESS='READ_TIMESTAMP %s'", t.Format(time.RFC3339Nano))); err != nil {
 		return err
 	}


### PR DESCRIPTION
Some of the examples missed a call to conn.Close().

Updates https://github.com/googleapis/google-cloud-go/issues/11017