### PR TITLE
feat: read-only transaction with options

### DIFF
--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -338,6 +338,69 @@ func TestReadOnlyTransactionWithStaleness(t *testing.T) {
 	}
 }
 
+func TestReadOnlyTransactionWithOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	db, server, teardown := setupTestDBConnection(t)
+	defer teardown()
+	// Set max open connections to 1 to force a failure if there is a connection leak.
+	db.SetMaxOpenConns(1)
+
+	tx, err := BeginReadOnlyTransaction(ctx, db,
+		ReadOnlyTransactionOptions{TimestampBound: spanner.ExactStaleness(10 * time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	useTx := func(tx *sql.Tx) {
+		rows, err := tx.Query(testutil.SelectFooFromBar)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for rows.Next() {
+		}
+		if rows.Err() != nil {
+			t.Fatal(rows.Err())
+		}
+		_ = rows.Close()
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	useTx(tx)
+
+	requests := drainRequestsFromServer(server.TestSpanner)
+	beginReadOnlyRequests := filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	if g, w := len(beginReadOnlyRequests), 1; g != w {
+		t.Fatalf("begin requests count mismatch\nGot: %v\nWant: %v", g, w)
+	}
+	beginReq := beginReadOnlyRequests[0]
+	if beginReq.GetOptions().GetReadOnly().GetExactStaleness() == nil {
+		t.Fatalf("missing exact_staleness option on BeginTransaction request")
+	}
+
+	// Verify that the staleness option is not 'sticky' on the database.
+	// Running a second transaction also verifies that there is no connection
+	// leak, as the database has max one connection in the pool.
+	tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	useTx(tx)
+
+	requests = drainRequestsFromServer(server.TestSpanner)
+	beginReadOnlyRequests = filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	if g, w := len(beginReadOnlyRequests), 1; g != w {
+		t.Fatalf("begin requests count mismatch\nGot: %v\nWant: %v", g, w)
+	}
+	beginReq = beginReadOnlyRequests[0]
+	if beginReq.GetOptions().GetReadOnly().GetExactStaleness() != nil {
+		t.Fatalf("got unexpected exact_staleness option on BeginTransaction request")
+	}
+}
+
 func TestSimpleReadWriteTransaction(t *testing.T) {
 	t.Parallel()
 

--- a/examples/read-only-transaction-with-options/main.go
+++ b/examples/read-only-transaction-with-options/main.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	spannerdriver "github.com/googleapis/go-sql-spanner"
+	"github.com/googleapis/go-sql-spanner/examples"
+)
+
+// Sample showing how to execute a read-only transaction with specific options on a Spanner database.
+//
+// Execute the sample with the command `go run main.go` from this directory.
+func readOnlyTransactionWithOptions(projectId, instanceId, databaseId string) error {
+	ctx := context.Background()
+	db, err := sql.Open("spanner", fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Start a read-only transaction on the Spanner database using a staleness option.
+	tx, err := spannerdriver.BeginReadOnlyTransaction(
+		ctx, db, spannerdriver.ReadOnlyTransactionOptions{
+			TimestampBound: spanner.ExactStaleness(time.Second * 10),
+		})
+	if err != nil {
+		return err
+	}
+	fmt.Println("Started a read-only transaction with a staleness option")
+
+	// Use the read-only transaction...
+
+	// Committing or rolling back a read-only transaction will not execute an actual Commit or Rollback
+	// on the database, but it is needed in order to release the resources that are held by the read-only
+	// transaction. Failing to do so will cause the connection that is used for the transaction to be leaked.
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	examples.RunSampleOnEmulator(readOnlyTransactionWithOptions)
+}


### PR DESCRIPTION
Adds a function for starting a read-only transaction with Spanner options. This function takes a custom Spanner ReadOnlyTransactionOptions struct as input argument, which in the future can be extended to add any new options that Spanner might add.

The transaction options that are given for the transaction are only used for this one transaction, instead of being persisted on the connection.