### PR TITLE
feat: auto-partition queries

### DIFF
--- a/checksum_row_iterator.go
+++ b/checksum_row_iterator.go
@@ -246,6 +246,6 @@ func (it *checksumRowIterator) Stop() {
 	}
 }
 
-func (it *checksumRowIterator) Metadata() *sppb.ResultSetMetadata {
-	return it.metadata
+func (it *checksumRowIterator) Metadata() (*sppb.ResultSetMetadata, error) {
+	return it.metadata, nil
 }

--- a/client_side_statement.go
+++ b/client_side_statement.go
@@ -368,6 +368,6 @@ func (t *clientSideIterator) Stop() {
 	t.metadata = nil
 }
 
-func (t *clientSideIterator) Metadata() *spannerpb.ResultSetMetadata {
-	return t.metadata
+func (t *clientSideIterator) Metadata() (*spannerpb.ResultSetMetadata, error) {
+	return t.metadata, nil
 }

--- a/driver.go
+++ b/driver.go
@@ -1776,8 +1776,8 @@ func (ri *wrappedRowIterator) Stop() {
 	ri.RowIterator.Stop()
 }
 
-func (ri *wrappedRowIterator) Metadata() *spannerpb.ResultSetMetadata {
-	return ri.RowIterator.Metadata
+func (ri *wrappedRowIterator) Metadata() (*spannerpb.ResultSetMetadata, error) {
+	return ri.RowIterator.Metadata, nil
 }
 
 func queryInNewRWTransaction(ctx context.Context, c *spanner.Client, statement spanner.Statement, options ExecOptions) (rowIterator, time.Time, error) {

--- a/driver.go
+++ b/driver.go
@@ -1486,7 +1486,10 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 		if execOptions.PartitionedQueryOptions.PartitionQuery {
 			return c.tx.partitionQuery(ctx, stmt, execOptions)
 		}
-		iter = c.tx.Query(ctx, stmt, execOptions.QueryOptions)
+		iter, err = c.tx.Query(ctx, stmt, execOptions)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &rows{it: iter, decodeOption: execOptions.DecodeOption}, nil
 }

--- a/examples/auto-partition-queries/main.go
+++ b/examples/auto-partition-queries/main.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+	spannerdriver "github.com/googleapis/go-sql-spanner"
+	"github.com/googleapis/go-sql-spanner/examples"
+)
+
+var createTableStatement = "CREATE TABLE Singers (SingerId INT64, Name STRING(MAX)) PRIMARY KEY (SingerId)"
+
+// Sample showing how to use a batch read-only transaction to auto-partition a query
+// and execute all partitions as if it was one query. This sample also shows how to
+// use DataBoost.
+//
+// See https://cloud.google.com/spanner/docs/databoost/databoost-overview for more
+// information.
+//
+// Execute the sample with the command `go run main.go` from this directory.
+func autoPartitionQuery(projectId, instanceId, databaseId string) error {
+	ctx := context.Background()
+	db, err := sql.Open("spanner", fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Insert 10 test rows.
+	if err := insertTestRows(db, 10); err != nil {
+		return err
+	}
+
+	// Start a batch read-only transaction.
+	tx, err := spannerdriver.BeginBatchReadOnlyTransaction(ctx, db, spannerdriver.BatchReadOnlyTransactionOptions{})
+	if err != nil {
+		return err
+	}
+	// Committing or rolling back a read-only transaction will not execute an actual Commit or Rollback
+	// on the database, but it is needed in order to release the resources that are held by the read-only
+	// transaction.
+	defer func() { _ = tx.Commit() }()
+
+	// Auto-partition and execute a query. The driver internal calls PartitionQuery
+	// and then executes each partition in a goroutine. The results of the various
+	// partitions are streamed into the row iterator that is returned for the query.
+	// The iterator will return the rows in arbitrary order.
+	rows, err := tx.QueryContext(ctx, "select * from singers", spannerdriver.ExecOptions{
+		PartitionedQueryOptions: spannerdriver.PartitionedQueryOptions{
+			// Set this option to true to automatically partition the query
+			// and execute each partition. The results are returned as one
+			// row iterator.
+			AutoPartitionQuery: true,
+			// MaxParallelism sets the maximum number of goroutines that
+			// will be used by the driver to execute the returned partitions.
+			// If not set, it will default to the number of available CPUs.
+			// The number of actual goroutines will never exceed the number of
+			// partitions that is returned by Spanner.
+			MaxParallelism: 8,
+		},
+		QueryOptions: spanner.QueryOptions{
+			// Set DataBoostEnabled to true to enable DataBoost.
+			// See https://cloud.google.com/spanner/docs/databoost/databoost-overview
+			// for more information.
+			DataBoostEnabled: true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	count := 0
+	var id int64
+	var name string
+	for rows.Next() {
+		if err := rows.Scan(&id, &name); err != nil {
+			return err
+		}
+		fmt.Printf("Id: %v, Name: %v\n", id, name)
+		count++
+	}
+	if rows.Err() != nil {
+		return rows.Err()
+	}
+	fmt.Printf("Executing all partitions returned a total of %v rows\n", count)
+
+	return nil
+}
+
+func main() {
+	examples.RunSampleOnEmulator(autoPartitionQuery, createTableStatement)
+}
+
+func insertTestRows(db *sql.DB, numRows int) error {
+	ctx := context.Background()
+
+	// Insert a few test rows.
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	// Insert the test rows in one batch.
+	if _, err := tx.ExecContext(ctx, "start batch dml"); err != nil {
+		tx.Rollback()
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, "INSERT INTO Singers (SingerId, Name) VALUES (?, ?)")
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	for i := 0; i < numRows; i++ {
+		if _, err := stmt.ExecContext(ctx, int64(i), fmt.Sprintf("Test %v", i)); err != nil {
+			_, _ = tx.ExecContext(ctx, "abort batch")
+			tx.Rollback()
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, "run batch"); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}

--- a/merged_row_iterator.go
+++ b/merged_row_iterator.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spannerdriver
+
+import (
+	"context"
+	"sync"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+var _ rowIterator = &mergedRowIterator{}
+
+type mergedRowIterator struct {
+	mu     sync.Mutex
+	buffer []*spanner.Row
+	err    error
+	pIndex int
+
+	partitionedQuery *PartitionedQuery
+	maxParallelism   int
+}
+
+func createMergedIterator(partitionedQuery *PartitionedQuery, maxParallelism int) *mergedRowIterator {
+	return &mergedRowIterator{
+		partitionedQuery: partitionedQuery,
+		maxParallelism:   maxParallelism,
+		buffer:           make([]*spanner.Row, 0, 10),
+	}
+}
+
+func (m *mergedRowIterator) run(ctx context.Context) {
+	parallelism := m.maxParallelism
+	if len(m.partitionedQuery.Partitions) < parallelism {
+		parallelism = len(m.partitionedQuery.Partitions)
+	}
+
+	for i := 0; i < parallelism; i++ {
+		go m.produceRows(ctx)
+	}
+}
+
+func (m *mergedRowIterator) produceRows(ctx context.Context) {
+	for {
+		index := m.nextIndex()
+		if index > len(m.partitionedQuery.Partitions) {
+			break
+		}
+		m.produceRowsFromPartition(ctx, index)
+	}
+}
+
+func (m *mergedRowIterator) nextIndex() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	index := m.pIndex
+	m.pIndex++
+
+	return index
+}
+
+func (m *mergedRowIterator) produceRowsFromPartition(ctx context.Context, index int) {
+	rows, err := m.partitionedQuery.execute(ctx, index)
+}
+
+func (m *mergedRowIterator) Next() (*spanner.Row, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mergedRowIterator) Stop() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mergedRowIterator) Metadata() *sppb.ResultSetMetadata {
+	//TODO implement me
+	panic("implement me")
+}

--- a/merged_row_iterator.go
+++ b/merged_row_iterator.go
@@ -16,47 +16,81 @@ package spannerdriver
 
 import (
 	"context"
+	"log/slog"
+	"runtime"
 	"sync"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/api/iterator"
 )
 
 var _ rowIterator = &mergedRowIterator{}
 
+// mergedRowIterator is a row iterator that starts up to maxParallelism
+// goroutines and reads data from partitions of a PartitionedQuery. The
+// rows that are read from the partitions are put in a buffer. This
+// iterator returns the rows from that buffer.
+//
+// The rows from the underlying partitions are returned in arbitrary
+// order.
 type mergedRowIterator struct {
-	mu     sync.Mutex
-	buffer []*spanner.Row
-	err    error
-	pIndex int
+	mu           sync.Mutex
+	err          error
+	pIndex       int
+	stopped      bool
+	numProducers int
+	metadata     *sppb.ResultSetMetadata
 
+	buffer        chan *spanner.Row
+	done          chan struct{}
+	metadataReady chan struct{}
+
+	logger           *slog.Logger
 	partitionedQuery *PartitionedQuery
 	maxParallelism   int
 }
 
-func createMergedIterator(partitionedQuery *PartitionedQuery, maxParallelism int) *mergedRowIterator {
+func createMergedIterator(logger *slog.Logger, partitionedQuery *PartitionedQuery, maxParallelism int) *mergedRowIterator {
+	if maxParallelism <= 0 {
+		maxParallelism = runtime.NumCPU()
+	}
 	return &mergedRowIterator{
+		logger:           logger.With("type", "merged_iterator", "stmt", partitionedQuery.stmt.SQL, "parallelism", maxParallelism),
 		partitionedQuery: partitionedQuery,
 		maxParallelism:   maxParallelism,
-		buffer:           make([]*spanner.Row, 0, 10),
+		buffer:           make(chan *spanner.Row, 10),
+		done:             make(chan struct{}),
+		metadataReady:    make(chan struct{}),
 	}
 }
 
 func (m *mergedRowIterator) run(ctx context.Context) {
+	m.logger.DebugContext(ctx, "run")
 	parallelism := m.maxParallelism
 	if len(m.partitionedQuery.Partitions) < parallelism {
 		parallelism = len(m.partitionedQuery.Partitions)
 	}
 
+	m.numProducers = parallelism
 	for i := 0; i < parallelism; i++ {
 		go m.produceRows(ctx)
 	}
 }
 
 func (m *mergedRowIterator) produceRows(ctx context.Context) {
+	m.logger.DebugContext(ctx, "produceRows")
+	defer func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.numProducers--
+		if m.numProducers == 0 {
+			m.stopLocked()
+		}
+	}()
 	for {
 		index := m.nextIndex()
-		if index > len(m.partitionedQuery.Partitions) {
+		if index >= len(m.partitionedQuery.Partitions) || m.hasErr() {
 			break
 		}
 		m.produceRowsFromPartition(ctx, index)
@@ -64,6 +98,7 @@ func (m *mergedRowIterator) produceRows(ctx context.Context) {
 }
 
 func (m *mergedRowIterator) nextIndex() int {
+	m.logger.Debug("nextIndex")
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	index := m.pIndex
@@ -73,20 +108,116 @@ func (m *mergedRowIterator) nextIndex() int {
 }
 
 func (m *mergedRowIterator) produceRowsFromPartition(ctx context.Context, index int) {
-	rows, err := m.partitionedQuery.execute(ctx, index)
+	m.logger.DebugContext(ctx, "produceRowsFromPartition", "index", index)
+	r, err := m.partitionedQuery.execute(ctx, index)
+	if err != nil {
+		m.registerErr(err)
+		return
+	}
+	defer func() { _ = r.Close() }()
+
+	first := true
+	it := r.it
+	for {
+		row, err := it.Next()
+		if err != nil && err != iterator.Done {
+			m.registerErr(err)
+			return
+		}
+		if index == 0 && first {
+			first = false
+			m.mu.Lock()
+			m.metadata = it.Metadata()
+			m.mu.Unlock()
+			close(m.metadataReady)
+		}
+		if err == iterator.Done {
+			return
+		}
+		select {
+		case m.buffer <- row:
+		case <-m.done:
+			return
+		}
+	}
+}
+
+func (m *mergedRowIterator) isStopped() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.err != nil
+}
+
+func (m *mergedRowIterator) hasErr() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.err != nil
+}
+
+func (m *mergedRowIterator) registerErr(err error) {
+	m.logger.Debug("registerErr", "err", err)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err == nil {
+		m.err = err
+	}
 }
 
 func (m *mergedRowIterator) Next() (*spanner.Row, error) {
-	//TODO implement me
-	panic("implement me")
+	m.logger.Debug("Next")
+	m.mu.Lock()
+	if m.err != nil {
+		defer m.mu.Unlock()
+		return nil, m.err
+	}
+	m.mu.Unlock()
+
+	// Pick an element from the buffer if there is any.
+	// This prevents the select statement from selecting 'done'
+	// when all producers are done, but there are still elements
+	// in the buffer.
+	if len(m.buffer) > 0 {
+		select {
+		case v := <-m.buffer:
+			return v, nil
+		default:
+			// fallthrough
+		}
+	}
+
+	select {
+	case v := <-m.buffer:
+		return v, nil
+	case <-m.done:
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.err != nil {
+			return nil, m.err
+		}
+		return nil, iterator.Done
+	}
 }
 
 func (m *mergedRowIterator) Stop() {
-	//TODO implement me
-	panic("implement me")
+	m.logger.Debug("Stop")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopLocked()
+}
+
+func (m *mergedRowIterator) stopLocked() {
+	m.logger.Debug("stopLocked")
+	if !m.stopped {
+		m.stopped = true
+		close(m.done)
+	}
 }
 
 func (m *mergedRowIterator) Metadata() *sppb.ResultSetMetadata {
-	//TODO implement me
-	panic("implement me")
+	m.logger.Debug("Metadata")
+	select {
+	case <-m.metadataReady:
+	case <-m.done:
+	}
+	return m.metadata
 }

--- a/partitioned_query_test.go
+++ b/partitioned_query_test.go
@@ -321,6 +321,7 @@ func TestAutoPartitionQuery_ExecuteError(t *testing.T) {
 	ctx := context.Background()
 	db, server, teardown := setupTestDBConnection(t)
 	defer teardown()
+	db.SetMaxOpenConns(1)
 
 	for maxResultsPerPartition := range []int{0, 1, 5, 50, 200} {
 		tx, err := BeginBatchReadOnlyTransaction(ctx, db, BatchReadOnlyTransactionOptions{})

--- a/rows.go
+++ b/rows.go
@@ -62,7 +62,12 @@ func (r *rows) getColumns() {
 				return
 			}
 		}
-		rowType := r.it.Metadata().RowType
+		metadata, err := r.it.Metadata()
+		if err != nil {
+			r.dirtyErr = err
+			return
+		}
+		rowType := metadata.RowType
 		r.cols = make([]string, len(rowType.Fields))
 		for i, c := range rowType.Fields {
 			r.cols[i] = c.Name
@@ -82,16 +87,16 @@ func (r *rows) getColumns() {
 func (r *rows) Next(dest []driver.Value) error {
 	r.getColumns()
 	var row *spanner.Row
-	if r.dirtyRow != nil {
-		row = r.dirtyRow
-		r.dirtyRow = nil
-	} else if r.dirtyErr != nil {
+	if r.dirtyErr != nil {
 		err := r.dirtyErr
 		r.dirtyErr = nil
 		if err == iterator.Done {
 			return io.EOF
 		}
 		return err
+	} else if r.dirtyRow != nil {
+		row = r.dirtyRow
+		r.dirtyRow = nil
 	} else {
 		var err error
 		row, err = r.it.Next() // returns io.EOF when there is no next

--- a/rows_test.go
+++ b/rows_test.go
@@ -43,8 +43,8 @@ func (t *testIterator) Next() (*spanner.Row, error) {
 func (t *testIterator) Stop() {
 }
 
-func (t *testIterator) Metadata() *sppb.ResultSetMetadata {
-	return t.metadata
+func (t *testIterator) Metadata() (*sppb.ResultSetMetadata, error) {
+	return t.metadata, nil
 }
 
 func newRow(t *testing.T, cols []string, vals []interface{}) *spanner.Row {

--- a/testutil/inmem_spanner_server.go
+++ b/testutil/inmem_spanner_server.go
@@ -1135,16 +1135,13 @@ func (s *inMemSpannerServer) PartitionQuery(ctx context.Context, req *spannerpb.
 		if err != nil {
 			return nil, gstatus.Error(codes.Internal, "failed to generate random partition token")
 		}
-		partitions = append(partitions, &spannerpb.Partition{PartitionToken: randBytes(10)})
+		token := fmt.Sprintf("%s: %v", req.Sql, i)
+		partitions = append(partitions, &spannerpb.Partition{PartitionToken: []byte(token)})
 	}
 	return &spannerpb.PartitionResponse{
 		Partitions:  partitions,
 		Transaction: tx,
 	}, nil
-}
-
-func randRange(min, max int) int {
-	return rand.Intn(max-min) + min
 }
 
 func (s *inMemSpannerServer) PartitionRead(ctx context.Context, req *spannerpb.PartitionReadRequest) (*spannerpb.PartitionResponse, error) {

--- a/transaction.go
+++ b/transaction.go
@@ -110,7 +110,7 @@ func (tx *readOnlyTransaction) Query(ctx context.Context, stmt spanner.Statement
 		if tx.boTx == nil {
 			return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "AutoPartitionQuery is only supported for batch read-only transactions"))
 		}
-		pq, err := tx.partitionQueryTemp(ctx, stmt, execOptions)
+		pq, err := tx.createPartitionedQuery(ctx, stmt, execOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -125,14 +125,14 @@ func (tx *readOnlyTransaction) Query(ctx context.Context, stmt spanner.Statement
 }
 
 func (tx *readOnlyTransaction) partitionQuery(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (driver.Rows, error) {
-	pq, err := tx.partitionQueryTemp(ctx, stmt, execOptions)
+	pq, err := tx.createPartitionedQuery(ctx, stmt, execOptions)
 	if err != nil {
 		return nil, err
 	}
 	return &partitionedQueryRows{partitionedQuery: pq}, nil
 }
 
-func (tx *readOnlyTransaction) partitionQueryTemp(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (*PartitionedQuery, error) {
+func (tx *readOnlyTransaction) createPartitionedQuery(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (*PartitionedQuery, error) {
 	if tx.boTx == nil {
 		return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "partitionQuery is only supported for batch read-only transactions"))
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -35,7 +35,7 @@ type contextTransaction interface {
 	Commit() error
 	Rollback() error
 	resetForRetry(ctx context.Context) error
-	Query(ctx context.Context, stmt spanner.Statement, options spanner.QueryOptions) rowIterator
+	Query(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (rowIterator, error)
 	partitionQuery(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (driver.Rows, error)
 	ExecContext(ctx context.Context, stmt spanner.Statement, options spanner.QueryOptions) (int64, error)
 
@@ -104,12 +104,32 @@ func (tx *readOnlyTransaction) resetForRetry(ctx context.Context) error {
 	return nil
 }
 
-func (tx *readOnlyTransaction) Query(ctx context.Context, stmt spanner.Statement, options spanner.QueryOptions) rowIterator {
+func (tx *readOnlyTransaction) Query(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (rowIterator, error) {
 	tx.logger.DebugContext(ctx, "Query", "stmt", stmt.SQL)
-	return &readOnlyRowIterator{tx.roTx.QueryWithOptions(ctx, stmt, options)}
+	if execOptions.PartitionedQueryOptions.AutoPartitionQuery {
+		if tx.boTx == nil {
+			return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "AutoPartitionQuery is only supported for batch read-only transactions"))
+		}
+		pq, err := tx.partitionQueryTemp(ctx, stmt, execOptions)
+		if err != nil {
+			return nil, err
+		}
+		mi := createMergedIterator(tx.logger, pq, execOptions.PartitionedQueryOptions.MaxParallelism)
+		mi.run(ctx)
+		return mi, nil
+	}
+	return &readOnlyRowIterator{tx.roTx.QueryWithOptions(ctx, stmt, execOptions.QueryOptions)}, nil
 }
 
 func (tx *readOnlyTransaction) partitionQuery(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (driver.Rows, error) {
+	pq, err := tx.partitionQueryTemp(ctx, stmt, execOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &partitionedQueryRows{partitionedQuery: pq}, nil
+}
+
+func (tx *readOnlyTransaction) partitionQueryTemp(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (*PartitionedQuery, error) {
 	if tx.boTx == nil {
 		return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "partitionQuery is only supported for batch read-only transactions"))
 	}
@@ -117,13 +137,12 @@ func (tx *readOnlyTransaction) partitionQuery(ctx context.Context, stmt spanner.
 	if err != nil {
 		return nil, err
 	}
-	pq := &PartitionedQuery{
+	return &PartitionedQuery{
 		stmt:        stmt,
 		execOptions: execOptions,
 		tx:          tx.boTx,
 		Partitions:  partitions,
-	}
-	return &partitionedQueryRows{partitionedQuery: pq}, nil
+	}, nil
 }
 
 func (tx *readOnlyTransaction) ExecContext(_ context.Context, _ spanner.Statement, _ spanner.QueryOptions) (int64, error) {
@@ -360,28 +379,28 @@ func (tx *readWriteTransaction) resetForRetry(ctx context.Context) error {
 // Query executes a query using the read/write transaction and returns a
 // rowIterator that will automatically retry the read/write transaction if the
 // transaction is aborted during the query or while iterating the returned rows.
-func (tx *readWriteTransaction) Query(ctx context.Context, stmt spanner.Statement, options spanner.QueryOptions) rowIterator {
+func (tx *readWriteTransaction) Query(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (rowIterator, error) {
 	tx.logger.Debug("Query", "stmt", stmt.SQL)
 	// If internal retries have been disabled, we don't need to keep track of a
 	// running checksum for all results that we have seen.
 	if !tx.retryAborts {
-		return &readOnlyRowIterator{tx.rwTx.QueryWithOptions(ctx, stmt, options)}
+		return &readOnlyRowIterator{tx.rwTx.QueryWithOptions(ctx, stmt, execOptions.QueryOptions)}, nil
 	}
 
 	// If retries are enabled, we need to use a row iterator that will keep
 	// track of a running checksum of all the results that we see.
 	buffer := &bytes.Buffer{}
 	it := &checksumRowIterator{
-		RowIterator: tx.rwTx.QueryWithOptions(ctx, stmt, options),
+		RowIterator: tx.rwTx.QueryWithOptions(ctx, stmt, execOptions.QueryOptions),
 		ctx:         ctx,
 		tx:          tx,
 		stmt:        stmt,
-		options:     options,
+		options:     execOptions.QueryOptions,
 		buffer:      buffer,
 		enc:         gob.NewEncoder(buffer),
 	}
 	tx.statements = append(tx.statements, it)
-	return it
+	return it, nil
 }
 
 func (tx *readWriteTransaction) partitionQuery(ctx context.Context, stmt spanner.Statement, execOptions ExecOptions) (driver.Rows, error) {


### PR DESCRIPTION
Adds support for automatically partitioning queries, executing each partition, and merge the results that are returned into a single row iterator. This allows applications, tools, and frameworks to use partitioned queries as if they were normal queries.