### PR TITLE
feat: option for decode to native array

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -261,6 +261,7 @@ func ExampleCreateConnector() {
 func TestConnection_Reset(t *testing.T) {
 	txClosed := false
 	c := conn{
+		connector:         &connector{},
 		logger:            noopLogger,
 		readOnlyStaleness: spanner.ExactStaleness(time.Second),
 		batch:             &batch{tp: dml},

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -575,7 +575,7 @@ func TestQueryWithAllTypes(t *testing.T) {
 		query,
 		&testutil.StatementResult{
 			Type:      testutil.StatementResultResultSet,
-			ResultSet: testutil.CreateResultSetWithAllTypes(false),
+			ResultSet: testutil.CreateResultSetWithAllTypes(false, true),
 		},
 	)
 
@@ -1008,7 +1008,7 @@ func TestQueryWithNullParameters(t *testing.T) {
 		query,
 		&testutil.StatementResult{
 			Type:      testutil.StatementResultResultSet,
-			ResultSet: testutil.CreateResultSetWithAllTypes(true),
+			ResultSet: testutil.CreateResultSetWithAllTypes(true, true),
 		},
 	)
 
@@ -1212,7 +1212,7 @@ func TestQueryWithAllTypes_ReturnProto(t *testing.T) {
 		query,
 		&testutil.StatementResult{
 			Type:      testutil.StatementResultResultSet,
-			ResultSet: testutil.CreateResultSetWithAllTypes(false),
+			ResultSet: testutil.CreateResultSetWithAllTypes(false, true),
 		},
 	)
 
@@ -1306,6 +1306,433 @@ func TestQueryWithAllTypes_ReturnProto(t *testing.T) {
 			t.Fatal(rows.Err())
 		}
 		rows.Close()
+	}
+}
+
+func TestQueryWithAllPrimitiveTypes(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnectionWithParams(t, "DecodeToPrimitiveArrays=true")
+	defer teardown()
+	query := `SELECT *
+             FROM Test
+             WHERE ColBool=@bool 
+             AND   ColString=@string
+             AND   ColBytes=@bytes
+             AND   ColInt=@int64
+             AND   ColFloat32=@float32
+             AND   ColFloat64=@float64
+             AND   ColNumeric=@numeric
+             AND   ColDate=@date
+             AND   ColTimestamp=@timestamp
+             AND   ColJson=@json
+             AND   ColBoolArray=@boolArray
+             AND   ColStringArray=@stringArray
+             AND   ColBytesArray=@bytesArray
+             AND   ColIntArray=@int64Array
+             AND   ColFloat32Array=@float32Array
+             AND   ColFloat64Array=@float64Array
+             AND   ColNumericArray=@numericArray
+             AND   ColDateArray=@dateArray
+             AND   ColTimestampArray=@timestampArray
+             AND   ColJsonArray=@jsonArray`
+	_ = server.TestSpanner.PutStatementResult(
+		query,
+		&testutil.StatementResult{
+			Type:      testutil.StatementResultResultSet,
+			ResultSet: testutil.CreateResultSetWithAllTypes(false, false),
+		},
+	)
+
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+	ts, _ := time.Parse(time.RFC3339Nano, "2021-07-22T10:26:17.123Z")
+	ts1, _ := time.Parse(time.RFC3339Nano, "2021-07-21T21:07:59.339911800Z")
+	ts2, _ := time.Parse(time.RFC3339Nano, "2021-07-27T21:07:59.339911800Z")
+	tsAlt, _ := time.Parse(time.RFC3339Nano, "2000-01-01T00:00:00Z")
+	rows, err := stmt.QueryContext(
+		context.Background(),
+		true,
+		"test",
+		[]byte("testbytes"),
+		uint(5),
+		float32(3.14),
+		3.14,
+		numeric("6.626"),
+		civil.Date{Year: 2021, Month: 7, Day: 21},
+		ts,
+		nullJson(true, `{"key":"value","other-key":["value1","value2"]}`),
+		[]bool{true, false},
+		[]string{"test1", "test2"},
+		[][]byte{[]byte("testbytes1"), []byte("testbytes2")},
+		[]int64{1, 2},
+		[]float32{3.14, -99.99},
+		[]float64{6.626, 10.01},
+		[]spanner.NullNumeric{nullNumeric(true, "3.14"), nullNumeric(true, "10.01")},
+		[]civil.Date{{Year: 2000, Month: 2, Day: 29}, {Year: 2021, Month: 7, Day: 27}},
+		[]time.Time{ts1, ts2},
+		[]spanner.NullJSON{
+			nullJson(true, `{"key1": "value1", "other-key1": ["value1", "value2"]}`),
+			nullJson(true, `{"key2": "value2", "other-key2": ["value1", "value2"]}`),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var b bool
+		var s string
+		var bt []byte
+		var i int64
+		var f32 float32
+		var f float64
+		var r big.Rat
+		var d civil.Date
+		var ts time.Time
+		var j spanner.NullJSON
+		var p []byte
+		var e int64
+		var bArray []bool
+		var sArray []string
+		var btArray [][]byte
+		var iArray []int64
+		var f32Array []float32
+		var fArray []float64
+		var rArray []spanner.NullNumeric
+		var dArray []civil.Date
+		var tsArray []time.Time
+		var jArray []spanner.NullJSON
+		var pArray [][]byte
+		var eArray []int64
+		err = rows.Scan(&b, &s, &bt, &i, &f32, &f, &r, &d, &ts, &j, &p, &e, &bArray, &sArray, &btArray, &iArray, &f32Array, &fArray, &rArray, &dArray, &tsArray, &jArray, &pArray, &eArray)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if g, w := b, true; g != w {
+			t.Errorf("row value mismatch for bool\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := s, "test"; g != w {
+			t.Errorf("row value mismatch for string\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := bt, []byte("testbytes"); !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for bytes\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := i, int64(5); g != w {
+			t.Errorf("row value mismatch for int64\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := f32, float32(3.14); g != w {
+			t.Errorf("row value mismatch for float32\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := f, 3.14; g != w {
+			t.Errorf("row value mismatch for float64\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := r, numeric("6.626"); g.Cmp(&w) != 0 {
+			t.Errorf("row value mismatch for numeric\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := d, date("2021-07-21"); !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for date\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := ts, time.Date(2021, 7, 21, 21, 7, 59, 339911800, time.UTC); g != w {
+			t.Errorf("row value mismatch for timestamp\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := j, nullJson(true, `{"key":"value","other-key":["value1","value2"]}`); !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for json\nGot: %v\nWant: %v", g, w)
+		}
+		wantSingerEnumValue := pb.Genre_ROCK
+		wantSingerProtoMsg := pb.SingerInfo{
+			SingerId:    proto.Int64(1),
+			BirthDate:   proto.String("January"),
+			Nationality: proto.String("Country1"),
+			Genre:       &wantSingerEnumValue,
+		}
+		gotSingerProto := pb.SingerInfo{}
+		if err := proto.Unmarshal(p, &gotSingerProto); err != nil {
+			t.Fatalf("failed to unmarshal proto: %v", err)
+		}
+		if g, w := &gotSingerProto, &wantSingerProtoMsg; !cmp.Equal(g, w, cmpopts.IgnoreUnexported(pb.SingerInfo{})) {
+			t.Errorf("row value mismatch for proto\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := pb.Genre(e), wantSingerEnumValue; g != w {
+			t.Errorf("row value mismatch for enum\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := bArray, []bool{true, true, false}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for bool array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := sArray, []string{"test1", "alt", "test2"}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for string array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := btArray, [][]byte{[]byte("testbytes1"), []byte("altbytes"), []byte("testbytes2")}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for bytes array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := iArray, []int64{1, 0, 2}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for int array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := f32Array, []float32{3.14, 0.0, -99.99}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for float32 array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := fArray, []float64{6.626, 0.0, 10.01}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for float64 array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := rArray, []spanner.NullNumeric{nullNumeric(true, "3.14"), nullNumeric(true, "1.0"), nullNumeric(true, "10.01")}; !cmp.Equal(g, w, cmp.AllowUnexported(big.Rat{}, big.Int{})) {
+			t.Errorf("row value mismatch for numeric array\n Got: %v\nWant: %v", g, w)
+		}
+		if g, w := dArray, []civil.Date{{Year: 2000, Month: 2, Day: 29}, {Year: 2000, Month: 1, Day: 1}, {Year: 2021, Month: 7, Day: 27}}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for date array\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := tsArray, []time.Time{ts1, tsAlt, ts2}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for timestamp array\n Got: %v\nWant: %v", g, w)
+		}
+		if g, w := jArray, []spanner.NullJSON{
+			nullJson(true, `{"key1": "value1", "other-key1": ["value1", "value2"]}`),
+			nullJson(true, "{}"),
+			nullJson(true, `{"key2": "value2", "other-key2": ["value1", "value2"]}`),
+		}; !cmp.Equal(g, w) {
+			t.Errorf("row value mismatch for json array\n Got: %v\nWant: %v", g, w)
+		}
+		if g, w := len(pArray), 3; g != w {
+			t.Errorf("row value length mismatch for proto array\nGot: %v\nWant: %v", g, w)
+		}
+		wantSinger2ProtoEnum := pb.Genre_FOLK
+		wantSinger2ProtoMsg := pb.SingerInfo{
+			SingerId:    proto.Int64(2),
+			BirthDate:   proto.String("February"),
+			Nationality: proto.String("Country2"),
+			Genre:       &wantSinger2ProtoEnum,
+		}
+		gotSingerProto1 := pb.SingerInfo{}
+		if err := proto.Unmarshal(pArray[0], &gotSingerProto1); err != nil {
+			t.Fatalf("failed to unmarshal proto: %v", err)
+		}
+		gotSingerProtoAlt := pb.SingerInfo{}
+		if err := proto.Unmarshal(pArray[1], &gotSingerProtoAlt); err != nil {
+			t.Fatalf("failed to unmarshal proto: %v", err)
+		}
+		gotSingerProto2 := pb.SingerInfo{}
+		if err := proto.Unmarshal(pArray[2], &gotSingerProto2); err != nil {
+			t.Fatalf("failed to unmarshal proto: %v", err)
+		}
+		if g, w := &gotSingerProto1, &wantSingerProtoMsg; !cmp.Equal(g, w, cmpopts.IgnoreUnexported(pb.SingerInfo{})) {
+			t.Errorf("row value mismatch for proto\nGot: %v\nWant: %v", g, w)
+		}
+		if g, w := &gotSingerProtoAlt, &wantSingerProtoMsg; !cmp.Equal(g, w, cmpopts.IgnoreUnexported(pb.SingerInfo{})) {
+			t.Errorf("row value mismatch for proto\n Got: %v\nWant: %v", g, w)
+		}
+		if g, w := &gotSingerProto2, &wantSinger2ProtoMsg; !cmp.Equal(g, w, cmpopts.IgnoreUnexported(pb.SingerInfo{})) {
+			t.Errorf("row value mismatch for proto\nGot: %v\nWant: %v", g, w)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+	requests := drainRequestsFromServer(server.TestSpanner)
+	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	if g, w := len(sqlRequests), 1; g != w {
+		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
+	}
+	req := sqlRequests[0].(*sppb.ExecuteSqlRequest)
+	if g, w := len(req.ParamTypes), 20; g != w {
+		t.Fatalf("param types length mismatch\nGot: %v\nWant: %v", g, w)
+	}
+	if g, w := len(req.Params.Fields), 20; g != w {
+		t.Fatalf("params length mismatch\nGot: %v\nWant: %v", g, w)
+	}
+	wantParams := []struct {
+		name  string
+		code  sppb.TypeCode
+		array bool
+		value interface{}
+	}{
+		{
+			name:  "bool",
+			code:  sppb.TypeCode_BOOL,
+			value: true,
+		},
+		{
+			name:  "string",
+			code:  sppb.TypeCode_STRING,
+			value: "test",
+		},
+		{
+			name:  "bytes",
+			code:  sppb.TypeCode_BYTES,
+			value: base64.StdEncoding.EncodeToString([]byte("testbytes")),
+		},
+		{
+			name:  "int64",
+			code:  sppb.TypeCode_INT64,
+			value: "5",
+		},
+		{
+			name:  "float32",
+			code:  sppb.TypeCode_FLOAT32,
+			value: float64(float32(3.14)),
+		},
+		{
+			name:  "float64",
+			code:  sppb.TypeCode_FLOAT64,
+			value: 3.14,
+		},
+		{
+			name:  "numeric",
+			code:  sppb.TypeCode_NUMERIC,
+			value: "6.626000000",
+		},
+		{
+			name:  "date",
+			code:  sppb.TypeCode_DATE,
+			value: "2021-07-21",
+		},
+		{
+			name:  "timestamp",
+			code:  sppb.TypeCode_TIMESTAMP,
+			value: "2021-07-22T10:26:17.123Z",
+		},
+		{
+			name:  "json",
+			code:  sppb.TypeCode_JSON,
+			value: `{"key":"value","other-key":["value1","value2"]}`,
+		},
+		{
+			name:  "boolArray",
+			code:  sppb.TypeCode_BOOL,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_BoolValue{BoolValue: true}},
+				{Kind: &structpb.Value_BoolValue{BoolValue: false}},
+			}},
+		},
+		{
+			name:  "stringArray",
+			code:  sppb.TypeCode_STRING,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: "test1"}},
+				{Kind: &structpb.Value_StringValue{StringValue: "test2"}},
+			}},
+		},
+		{
+			name:  "bytesArray",
+			code:  sppb.TypeCode_BYTES,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: base64.StdEncoding.EncodeToString([]byte("testbytes1"))}},
+				{Kind: &structpb.Value_StringValue{StringValue: base64.StdEncoding.EncodeToString([]byte("testbytes2"))}},
+			}},
+		},
+		{
+			name:  "int64Array",
+			code:  sppb.TypeCode_INT64,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: "1"}},
+				{Kind: &structpb.Value_StringValue{StringValue: "2"}},
+			}},
+		},
+		{
+			name:  "float32Array",
+			code:  sppb.TypeCode_FLOAT32,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_NumberValue{NumberValue: float64(float32(3.14))}},
+				{Kind: &structpb.Value_NumberValue{NumberValue: float64(float32(-99.99))}},
+			}},
+		},
+		{
+			name:  "float64Array",
+			code:  sppb.TypeCode_FLOAT64,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_NumberValue{NumberValue: 6.626}},
+				{Kind: &structpb.Value_NumberValue{NumberValue: 10.01}},
+			}},
+		},
+		{
+			name:  "numericArray",
+			code:  sppb.TypeCode_NUMERIC,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: "3.140000000"}},
+				{Kind: &structpb.Value_StringValue{StringValue: "10.010000000"}},
+			}},
+		},
+		{
+			name:  "dateArray",
+			code:  sppb.TypeCode_DATE,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: "2000-02-29"}},
+				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-27"}},
+			}},
+		},
+		{
+			name:  "timestampArray",
+			code:  sppb.TypeCode_TIMESTAMP,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-21T21:07:59.3399118Z"}},
+				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-27T21:07:59.3399118Z"}},
+			}},
+		},
+		{
+			name:  "jsonArray",
+			code:  sppb.TypeCode_JSON,
+			array: true,
+			value: &structpb.ListValue{Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: `{"key1":"value1","other-key1":["value1","value2"]}`}},
+				{Kind: &structpb.Value_StringValue{StringValue: `{"key2":"value2","other-key2":["value1","value2"]}`}},
+			}},
+		},
+	}
+	for _, wantParam := range wantParams {
+		if pt, ok := req.ParamTypes[wantParam.name]; ok {
+			if wantParam.array {
+				if g, w := pt.Code, sppb.TypeCode_ARRAY; g != w {
+					t.Errorf("param type mismatch\nGot: %v\nWant: %v", g, w)
+				}
+				if g, w := pt.ArrayElementType.Code, wantParam.code; g != w {
+					t.Errorf("param array element type mismatch\nGot: %v\nWant: %v", g, w)
+				}
+			} else {
+				if g, w := pt.Code, wantParam.code; g != w {
+					t.Errorf("param type mismatch\nGot: %v\nWant: %v", g, w)
+				}
+			}
+		} else {
+			t.Errorf("no param type found for @%s", wantParam.name)
+		}
+		if val, ok := req.Params.Fields[wantParam.name]; ok {
+			var g interface{}
+			if wantParam.array {
+				g = val.GetListValue()
+			} else {
+				switch wantParam.code {
+				case sppb.TypeCode_BOOL:
+					g = val.GetBoolValue()
+				case sppb.TypeCode_FLOAT32:
+					g = val.GetNumberValue()
+				case sppb.TypeCode_FLOAT64:
+					g = val.GetNumberValue()
+				default:
+					g = val.GetStringValue()
+				}
+			}
+			if wantParam.array {
+				if !cmp.Equal(g, wantParam.value, cmpopts.IgnoreUnexported(structpb.ListValue{}, structpb.Value{})) {
+					t.Errorf("array param value mismatch\nGot:  %v\nWant: %v", g, wantParam.value)
+				}
+			} else {
+				if g != wantParam.value {
+					t.Errorf("param value mismatch\nGot: %v\nWant: %v", g, wantParam.value)
+				}
+			}
+		} else {
+			t.Errorf("no value found for param @%s", wantParam.name)
+		}
 	}
 }
 

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -1309,10 +1309,10 @@ func TestQueryWithAllTypes_ReturnProto(t *testing.T) {
 	}
 }
 
-func TestQueryWithAllPrimitiveTypes(t *testing.T) {
+func TestQueryWithAllNativeTypes(t *testing.T) {
 	t.Parallel()
 
-	db, server, teardown := setupTestDBConnectionWithParams(t, "DecodeToPrimitiveArrays=true")
+	db, server, teardown := setupTestDBConnectionWithParams(t, "DecodeToNativeArrays=true")
 	defer teardown()
 	query := `SELECT *
              FROM Test

--- a/examples/data-types/main.go
+++ b/examples/data-types/main.go
@@ -23,7 +23,6 @@ import (
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
-	_ "github.com/googleapis/go-sql-spanner"
 	spannerdriver "github.com/googleapis/go-sql-spanner"
 	"github.com/googleapis/go-sql-spanner/examples"
 )

--- a/rows.go
+++ b/rows.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
+	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"google.golang.org/api/iterator"
@@ -28,10 +30,12 @@ import (
 type rows struct {
 	it rowIterator
 
-	colsOnce     sync.Once
-	dirtyErr     error
-	cols         []string
-	decodeOption DecodeOption
+	colsOnce sync.Once
+	dirtyErr error
+	cols     []string
+
+	decodeOption            DecodeOption
+	decodeToPrimitiveArrays bool
 
 	dirtyRow *spanner.Row
 }
@@ -212,23 +216,47 @@ func (r *rows) Next(dest []driver.Value) error {
 		case sppb.TypeCode_ARRAY:
 			switch col.Type.ArrayElementType.Code {
 			case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
-				var v []spanner.NullInt64
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []int64
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullInt64
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_FLOAT32:
-				var v []spanner.NullFloat32
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []float32
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullFloat32
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_FLOAT64:
-				var v []spanner.NullFloat64
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []float64
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullFloat64
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_NUMERIC:
 				var v []spanner.NullNumeric
 				if err := col.Decode(&v); err != nil {
@@ -236,11 +264,19 @@ func (r *rows) Next(dest []driver.Value) error {
 				}
 				dest[i] = v
 			case sppb.TypeCode_STRING:
-				var v []spanner.NullString
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []string
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullString
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_JSON:
 				var v []spanner.NullJSON
 				if err := col.Decode(&v); err != nil {
@@ -254,23 +290,47 @@ func (r *rows) Next(dest []driver.Value) error {
 				}
 				dest[i] = v
 			case sppb.TypeCode_BOOL:
-				var v []spanner.NullBool
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []bool
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullBool
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_DATE:
-				var v []spanner.NullDate
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []civil.Date
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullDate
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			case sppb.TypeCode_TIMESTAMP:
-				var v []spanner.NullTime
-				if err := col.Decode(&v); err != nil {
-					return err
+				if r.decodeToPrimitiveArrays {
+					var v []time.Time
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
+				} else {
+					var v []spanner.NullTime
+					if err := col.Decode(&v); err != nil {
+						return err
+					}
+					dest[i] = v
 				}
-				dest[i] = v
 			default:
 				return fmt.Errorf("unsupported element type ARRAY<%v>", col.Type.ArrayElementType.Code)
 			}

--- a/rows.go
+++ b/rows.go
@@ -34,8 +34,8 @@ type rows struct {
 	dirtyErr error
 	cols     []string
 
-	decodeOption            DecodeOption
-	decodeToPrimitiveArrays bool
+	decodeOption         DecodeOption
+	decodeToNativeArrays bool
 
 	dirtyRow *spanner.Row
 }
@@ -216,7 +216,7 @@ func (r *rows) Next(dest []driver.Value) error {
 		case sppb.TypeCode_ARRAY:
 			switch col.Type.ArrayElementType.Code {
 			case sppb.TypeCode_INT64, sppb.TypeCode_ENUM:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []int64
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -230,7 +230,7 @@ func (r *rows) Next(dest []driver.Value) error {
 					dest[i] = v
 				}
 			case sppb.TypeCode_FLOAT32:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []float32
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -244,7 +244,7 @@ func (r *rows) Next(dest []driver.Value) error {
 					dest[i] = v
 				}
 			case sppb.TypeCode_FLOAT64:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []float64
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -264,7 +264,7 @@ func (r *rows) Next(dest []driver.Value) error {
 				}
 				dest[i] = v
 			case sppb.TypeCode_STRING:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []string
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -290,7 +290,7 @@ func (r *rows) Next(dest []driver.Value) error {
 				}
 				dest[i] = v
 			case sppb.TypeCode_BOOL:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []bool
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -304,7 +304,7 @@ func (r *rows) Next(dest []driver.Value) error {
 					dest[i] = v
 				}
 			case sppb.TypeCode_DATE:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []civil.Date
 					if err := col.Decode(&v); err != nil {
 						return err
@@ -318,7 +318,7 @@ func (r *rows) Next(dest []driver.Value) error {
 					dest[i] = v
 				}
 			case sppb.TypeCode_TIMESTAMP:
-				if r.decodeToPrimitiveArrays {
+				if r.decodeToNativeArrays {
 					var v []time.Time
 					if err := col.Decode(&v); err != nil {
 						return err

--- a/testutil/mocked_inmem_server.go
+++ b/testutil/mocked_inmem_server.go
@@ -224,7 +224,7 @@ func createSingersRow(idx int64) *structpb.ListValue {
 	}
 }
 
-func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
+func CreateResultSetWithAllTypes(nullValues, nullValuesInArrays bool) *spannerpb.ResultSet {
 	index := 0
 	fields := make([]*spannerpb.StructType_Field, 24)
 	fields[index] = &spannerpb.StructType_Field{
@@ -439,7 +439,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_BoolValue{BoolValue: true}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_BoolValue{BoolValue: true}}),
 				{Kind: &structpb.Value_BoolValue{BoolValue: false}},
 			}},
 		}}
@@ -447,7 +447,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "test1"}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "alt"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: "test2"}},
 			}},
 		}}
@@ -455,7 +455,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: base64.StdEncoding.EncodeToString([]byte("testbytes1"))}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: base64.StdEncoding.EncodeToString([]byte("altbytes"))}}),
 				{Kind: &structpb.Value_StringValue{StringValue: base64.StdEncoding.EncodeToString([]byte("testbytes2"))}},
 			}},
 		}}
@@ -463,7 +463,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "1"}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "0"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: "2"}},
 			}},
 		}}
@@ -471,7 +471,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_NumberValue{NumberValue: float64(float32(3.14))}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: float64(float32(0.0))}}),
 				{Kind: &structpb.Value_NumberValue{NumberValue: float64(float32(-99.99))}},
 			}},
 		}}
@@ -479,7 +479,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_NumberValue{NumberValue: 6.626}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: 0.0}}),
 				{Kind: &structpb.Value_NumberValue{NumberValue: 10.01}},
 			}},
 		}}
@@ -487,7 +487,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "3.14"}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "1.0"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: "10.01"}},
 			}},
 		}}
@@ -495,7 +495,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "2000-02-29"}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "2000-01-01"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-27"}},
 			}},
 		}}
@@ -503,7 +503,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-21T21:07:59.339911800Z"}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "2000-01-01T00:00:00Z"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: "2021-07-27T21:07:59.339911800Z"}},
 			}},
 		}}
@@ -511,7 +511,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				{Kind: &structpb.Value_StringValue{StringValue: `{"key1": "value1", "other-key1": ["value1", "value2"]}`}},
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "{}"}}),
 				{Kind: &structpb.Value_StringValue{StringValue: `{"key2": "value2", "other-key2": ["value1", "value2"]}`}},
 			}},
 		}}
@@ -519,7 +519,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				protoMessageProto(&singerProtoMsg),
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, protoMessageProto(&singerProtoMsg)),
 				protoMessageProto(&singer2ProtoMsg),
 			}},
 		}}
@@ -527,7 +527,7 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		rowValue[index] = &structpb.Value{Kind: &structpb.Value_ListValue{
 			ListValue: &structpb.ListValue{Values: []*structpb.Value{
 				protoEnumProto(&singerEnumValue),
-				{Kind: &structpb.Value_NullValue{}},
+				nullValueOrAlt(nullValuesInArrays, protoEnumProto(&singerEnumValue)),
 				protoEnumProto(&singer2ProtoEnum),
 			}},
 		}}
@@ -539,6 +539,13 @@ func CreateResultSetWithAllTypes(nullValues bool) *spannerpb.ResultSet {
 		Metadata: metadata,
 		Rows:     rows,
 	}
+}
+
+func nullValueOrAlt(nullValue bool, alt *structpb.Value) *structpb.Value {
+	if nullValue {
+		return &structpb.Value{Kind: &structpb.Value_NullValue{}}
+	}
+	return alt
 }
 
 func protoMessageProto(m proto.Message) *structpb.Value {


### PR DESCRIPTION
Adds an option to decode arrays to primitive Go array types. This enables the use of []bool, []int64, []float32, []float64, and []string arrays with the Spanner database/sql driver.

Enabling this option and trying to decode an array that contains a NULL element will result in an error being returned.

Fixes #331

Updates https://github.com/googleapis/go-gorm-spanner/issues/130
Updates https://github.com/googleapis/go-gorm-spanner/issues/133