### PR TITLE
fix: session leak when tx was aborted during commit

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -365,6 +365,9 @@ func (tx *readWriteTransaction) Commit() (err error) {
 			commitTs, err = tx.rwTx.Commit(ctx)
 			return err
 		})
+		if err == ErrAbortedDueToConcurrentModification {
+			tx.rwTx.Rollback(context.Background())
+		}
 	}
 	tx.close(&commitTs, err)
 	return err


### PR DESCRIPTION
The driver would leak a session if a read/write transaction was aborted during a Commit, and the retry of the transaction would fail due to concurrently modified data.

Fixes #380