### PR TITLE
deps: update supported Go version to 1.24

### DIFF
--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run integration tests on emulator

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -6,7 +6,7 @@ jobs:
   samples:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/snippets.yml
+++ b/.github/workflows/snippets.yml
@@ -6,7 +6,7 @@ jobs:
   samples:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Install tools
         run: |

--- a/README.md
+++ b/README.md
@@ -233,14 +233,10 @@ initial attempt and the retry attempt, the Aborted error will be propagated
 to the client application as an `spannerdriver.ErrAbortedDueToConcurrentModification`
 error.
 
-## [Go Versions Supported](#supported-versions)
+## Go Versions Supported
 
-Our libraries are compatible with at least the three most recent, major Go
-releases. They are currently compatible with:
-
-- Go 1.23
-- Go 1.22
-- Go 1.21
+The Spanner database/sql driver follows the [Go release policy](https://go.dev/doc/devel/release)
+and supports the two latest major Go versions.
 
 ## Authorization
 


### PR DESCRIPTION
Updates the policy for the supported Go versions and updates the test runners to use the two latest versions.