### PR TITLE
feat: support default isolation level for connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -114,6 +114,13 @@ type SpannerConn interface {
 	// mode and for read-only transaction.
 	SetReadOnlyStaleness(staleness spanner.TimestampBound) error
 
+	// IsolationLevel returns the current default isolation level that is
+	// used for read/write transactions on this connection.
+	IsolationLevel() sql.IsolationLevel
+	// SetIsolationLevel sets the default isolation level to use for read/write
+	// transactions on this connection.
+	SetIsolationLevel(level sql.IsolationLevel) error
+
 	// TransactionTag returns the transaction tag that will be applied to the next
 	// read/write transaction on this connection. The transaction tag that is set
 	// on the connection is cleared when a read/write transaction is started.
@@ -235,6 +242,10 @@ type conn struct {
 	autocommitDMLMode AutocommitDMLMode
 	// readOnlyStaleness is used for queries in autocommit mode and for read-only transactions.
 	readOnlyStaleness spanner.TimestampBound
+	// isolationLevel determines the default isolation level that is used for read/write
+	// transactions on this connection. This default is ignored if the BeginTx function is
+	// called with an isolation level other than sql.LevelDefault.
+	isolationLevel sql.IsolationLevel
 
 	// execOptions are applied to the next statement or transaction that is executed
 	// on this connection. It can also be set by passing it in as an argument to
@@ -307,6 +318,15 @@ func (c *conn) SetReadOnlyStaleness(staleness spanner.TimestampBound) error {
 func (c *conn) setReadOnlyStaleness(staleness spanner.TimestampBound) (driver.Result, error) {
 	c.readOnlyStaleness = staleness
 	return driver.ResultNoRows, nil
+}
+
+func (c *conn) IsolationLevel() sql.IsolationLevel {
+	return c.isolationLevel
+}
+
+func (c *conn) SetIsolationLevel(level sql.IsolationLevel) error {
+	c.isolationLevel = level
+	return nil
 }
 
 func (c *conn) MaxCommitDelay() time.Duration {
@@ -633,6 +653,7 @@ func (c *conn) ResetSession(_ context.Context) error {
 	c.autoBatchDmlUpdateCount = c.connector.connectorConfig.AutoBatchDmlUpdateCount
 	c.autoBatchDmlUpdateCountVerification = !c.connector.connectorConfig.DisableAutoBatchDmlUpdateCountVerification
 	c.retryAborts = c.connector.retryAbortsInternally
+	c.isolationLevel = c.connector.connectorConfig.IsolationLevel
 	// TODO: Reset the following fields to the connector default
 	c.autocommitDMLMode = Transactional
 	c.readOnlyStaleness = spanner.TimestampBound{}
@@ -888,10 +909,20 @@ func (c *conn) getTransactionOptions() ReadWriteTransactionOptions {
 	defer func() {
 		c.execOptions.TransactionOptions.TransactionTag = ""
 	}()
-	return ReadWriteTransactionOptions{
+	txOpts := ReadWriteTransactionOptions{
 		TransactionOptions:     c.execOptions.TransactionOptions,
 		DisableInternalRetries: !c.retryAborts,
 	}
+	// Only use the default isolation level from the connection if the ExecOptions
+	// did not contain a more specific isolation level.
+	if txOpts.TransactionOptions.IsolationLevel == spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED {
+		// This should never really return an error, but we check just to be absolutely sure.
+		level, err := toProtoIsolationLevel(c.isolationLevel)
+		if err == nil {
+			txOpts.TransactionOptions.IsolationLevel = level
+		}
+	}
+	return txOpts
 }
 
 func (c *conn) withTempReadOnlyTransactionOptions(options *ReadOnlyTransactionOptions) {

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spannerdriver
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/googleapis/go-sql-spanner/testutil"
+)
+
+func TestBeginTx(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+
+	tx, _ := db.BeginTx(ctx, &sql.TxOptions{})
+	_, _ = tx.ExecContext(ctx, testutil.UpdateBarSetFoo)
+	_ = tx.Rollback()
+
+	requests := drainRequestsFromServer(server.TestSpanner)
+	beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 1; g != w {
+		t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	request := beginRequests[0].(*spannerpb.BeginTransactionRequest)
+	if g, w := request.Options.GetIsolationLevel(), spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED; g != w {
+		t.Fatalf("begin isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestBeginTxWithIsolationLevel(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+
+	for _, level := range []sql.IsolationLevel{
+		sql.LevelDefault,
+		sql.LevelSnapshot,
+		sql.LevelRepeatableRead,
+		sql.LevelSerializable,
+	} {
+		originalLevel := level
+		for _, disableRetryAborts := range []bool{true, false} {
+			if disableRetryAborts {
+				level = WithDisableRetryAborts(originalLevel)
+			} else {
+				level = originalLevel
+			}
+			tx, _ := db.BeginTx(ctx, &sql.TxOptions{
+				Isolation: level,
+			})
+			_, _ = tx.ExecContext(ctx, testutil.UpdateBarSetFoo)
+			_ = tx.Rollback()
+
+			requests := drainRequestsFromServer(server.TestSpanner)
+			beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+			if g, w := len(beginRequests), 1; g != w {
+				t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
+			}
+			request := beginRequests[0].(*spannerpb.BeginTransactionRequest)
+			wantIsolationLevel, _ := toProtoIsolationLevel(originalLevel)
+			if g, w := request.Options.GetIsolationLevel(), wantIsolationLevel; g != w {
+				t.Fatalf("begin isolation level mismatch\n Got: %v\nWant: %v", g, w)
+			}
+		}
+	}
+}
+
+func TestBeginTxWithInvalidIsolationLevel(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+
+	for _, level := range []sql.IsolationLevel{
+		sql.LevelReadUncommitted,
+		sql.LevelReadCommitted,
+		sql.LevelWriteCommitted,
+		sql.LevelLinearizable,
+	} {
+		originalLevel := level
+		for _, disableRetryAborts := range []bool{true, false} {
+			if disableRetryAborts {
+				level = WithDisableRetryAborts(originalLevel)
+			} else {
+				level = originalLevel
+			}
+			_, err := db.BeginTx(ctx, &sql.TxOptions{
+				Isolation: level,
+			})
+			if err == nil {
+				t.Fatalf("BeginTx should have failed with invalid isolation level: %v", level)
+			}
+		}
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -1058,6 +1058,27 @@ func checkIsValidType(v driver.Value) bool {
 	return true
 }
 
+func toProtoIsolationLevel(level sql.IsolationLevel) (spannerpb.TransactionOptions_IsolationLevel, error) {
+	switch level {
+	case sql.LevelSerializable:
+		return spannerpb.TransactionOptions_SERIALIZABLE, nil
+	case sql.LevelRepeatableRead:
+		return spannerpb.TransactionOptions_REPEATABLE_READ, nil
+	case sql.LevelSnapshot:
+		return spannerpb.TransactionOptions_REPEATABLE_READ, nil
+	case sql.LevelDefault:
+		return spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, nil
+
+	// Unsupported and unknown isolation levels.
+	case sql.LevelReadUncommitted:
+	case sql.LevelReadCommitted:
+	case sql.LevelWriteCommitted:
+	case sql.LevelLinearizable:
+	default:
+	}
+	return spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid or unsupported isolation level: %v", level))
+}
+
 type spannerIsolationLevel sql.IsolationLevel
 
 const (

--- a/driver_test.go
+++ b/driver_test.go
@@ -161,6 +161,21 @@ func TestExtractDnsParts(t *testing.T) {
 			},
 		},
 		{
+			input: "projects/p/instances/i/databases/d?isolationLevel=repeatable_read;",
+			wantConnectorConfig: ConnectorConfig{
+				Project:  "p",
+				Instance: "i",
+				Database: "d",
+				Params: map[string]string{
+					"isolationlevel": "repeatable_read",
+				},
+			},
+			wantSpannerConfig: spanner.ClientConfig{
+				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
+				UserAgent:         userAgent,
+			},
+		},
+		{
 			input: "spanner.googleapis.com/projects/p/instances/i/databases/d?minSessions=200;maxSessions=1000;numChannels=10;disableRouteToLeader=true;enableEndToEndTracing=true;disableNativeMetrics=true;rpcPriority=Medium;optimizerVersion=1;optimizerStatisticsPackage=latest;databaseRole=child",
 			wantConnectorConfig: ConnectorConfig{
 				Host:     "spanner.googleapis.com",
@@ -287,6 +302,77 @@ func TestToProtoIsolationLevel(t *testing.T) {
 			t.Errorf("test %d: unexpected error for input %v: %v", i, test.input, err)
 		} else if g != test.want {
 			t.Errorf("test %d:\n Got: %v\nWant: %v", i, g, test.want)
+		}
+	}
+}
+
+func TestParseIsolationLevel(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    sql.IsolationLevel
+		wantErr bool
+	}{
+		{
+			input: "default",
+			want:  sql.LevelDefault,
+		},
+		{
+			input: " DEFAULT   ",
+			want:  sql.LevelDefault,
+		},
+		{
+			input: "read uncommitted",
+			want:  sql.LevelReadUncommitted,
+		},
+		{
+			input: "  read_uncommitted\n",
+			want:  sql.LevelReadUncommitted,
+		},
+		{
+			input: "read committed",
+			want:  sql.LevelReadCommitted,
+		},
+		{
+			input: "write committed",
+			want:  sql.LevelWriteCommitted,
+		},
+		{
+			input: "repeatable read",
+			want:  sql.LevelRepeatableRead,
+		},
+		{
+			input: "snapshot",
+			want:  sql.LevelSnapshot,
+		},
+		{
+			input: "serializable",
+			want:  sql.LevelSerializable,
+		},
+		{
+			input: "linearizable",
+			want:  sql.LevelLinearizable,
+		},
+		{
+			input:   "read serializable",
+			wantErr: true,
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+		{
+			input:   "read-committed",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		level, err := parseIsolationLevel(tc.input)
+		if tc.wantErr && err == nil {
+			t.Errorf("parseIsolationLevel(%q): expected error", tc.input)
+		} else if !tc.wantErr && err != nil {
+			t.Errorf("parseIsolationLevel(%q): unexpected error: %v", tc.input, err)
+		} else if level != tc.want {
+			t.Errorf("parseIsolationLevel(%q): got %v, want %v", tc.input, level, tc.want)
 		}
 	}
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -234,7 +234,61 @@ func TestExtractDnsParts(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestToProtoIsolationLevel(t *testing.T) {
+	tests := []struct {
+		input   sql.IsolationLevel
+		want    spannerpb.TransactionOptions_IsolationLevel
+		wantErr bool
+	}{
+		{
+			input: sql.LevelSerializable,
+			want:  spannerpb.TransactionOptions_SERIALIZABLE,
+		},
+		{
+			input: sql.LevelRepeatableRead,
+			want:  spannerpb.TransactionOptions_REPEATABLE_READ,
+		},
+		{
+			input: sql.LevelSnapshot,
+			want:  spannerpb.TransactionOptions_REPEATABLE_READ,
+		},
+		{
+			input: sql.LevelDefault,
+			want:  spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED,
+		},
+		{
+			input:   sql.LevelReadUncommitted,
+			wantErr: true,
+		},
+		{
+			input:   sql.LevelReadCommitted,
+			wantErr: true,
+		},
+		{
+			input:   sql.LevelWriteCommitted,
+			wantErr: true,
+		},
+		{
+			input:   sql.LevelLinearizable,
+			wantErr: true,
+		},
+		{
+			input:   sql.IsolationLevel(1000),
+			wantErr: true,
+		},
+	}
+	for i, test := range tests {
+		g, err := toProtoIsolationLevel(test.input)
+		if test.wantErr && err == nil {
+			t.Errorf("test %d: expected error for input %v, got none", i, test.input)
+		} else if !test.wantErr && err != nil {
+			t.Errorf("test %d: unexpected error for input %v: %v", i, test.input, err)
+		} else if g != test.want {
+			t.Errorf("test %d:\n Got: %v\nWant: %v", i, g, test.want)
+		}
+	}
 }
 
 func ExampleCreateConnector() {


### PR DESCRIPTION
Support setting a default isolation level for a connection and connector. All read/write transactions on a connection will use the default isolation level, unless an isolation level is specified in the BeginTx function call.