### PR TITLE
fix: skip Configurator func when marshalling to json

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -250,7 +250,7 @@ type ConnectorConfig struct {
 	// that will be used to create connections by the driver.Connector. Use this
 	// function to set any further advanced configuration options that cannot be set
 	// with a standard key/value pair in the Params map.
-	Configurator func(config *spanner.ClientConfig, opts *[]option.ClientOption)
+	Configurator func(config *spanner.ClientConfig, opts *[]option.ClientOption) `json:"-"`
 }
 
 func (cc *ConnectorConfig) String() string {

--- a/driver_test.go
+++ b/driver_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
@@ -742,6 +743,13 @@ func TestConn_CheckNamedValue(t *testing.T) {
 		if diff := cmp.Diff(test.want, value.Value); diff != "" {
 			t.Errorf("wrong result, got %#v expected %#v:\n%v", value.Value, test.want, diff)
 		}
+	}
+}
+
+func TestConnectorConfigJson(t *testing.T) {
+	_, err := json.Marshal(ConnectorConfig{})
+	if err != nil {
+		t.Fatalf("failed to marshal ConnectorConfig: %v", err)
 	}
 }
 


### PR DESCRIPTION
Do not include the Configurator func when marshalling a ConnectorConfig to json.

Fixes #409 