### PR TITLE
perf: add a cache for parsed statements

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -828,6 +828,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/conn.go
+++ b/conn.go
@@ -204,6 +204,7 @@ type SpannerConn interface {
 var _ SpannerConn = &conn{}
 
 type conn struct {
+	parser        *statementParser
 	connector     *connector
 	closed        bool
 	client        *spanner.Client
@@ -724,7 +725,7 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 
 func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, error) {
 	execOptions := c.options()
-	parsedSQL, args, err := parseParameters(query)
+	parsedSQL, args, err := c.parser.parseParameters(query)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +734,7 @@ func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, err
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	// Execute client side statement if it is one.
-	clientStmt, err := parseClientSideStatement(c, query)
+	clientStmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}
@@ -754,13 +755,13 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 		return pq.execute(ctx, execOptions.PartitionedQueryOptions.ExecutePartition.Index)
 	}
 
-	stmt, err := prepareSpannerStmt(query, args)
+	stmt, err := prepareSpannerStmt(c.parser, query, args)
 	if err != nil {
 		return nil, err
 	}
 	var iter rowIterator
 	if c.tx == nil {
-		statementType := detectStatementType(query)
+		statementType := c.parser.detectStatementType(query)
 		if statementType.statementType == statementTypeDml {
 			// Use a read/write transaction to execute the statement.
 			var commitTs time.Time
@@ -793,7 +794,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	// Execute client side statement if it is one.
-	stmt, err := parseClientSideStatement(c, query)
+	stmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}
@@ -808,7 +809,7 @@ func (c *conn) execContext(ctx context.Context, query string, execOptions ExecOp
 	// Clear the commit timestamp of this connection before we execute the statement.
 	c.commitTs = nil
 
-	statementInfo := detectStatementType(query)
+	statementInfo := c.parser.detectStatementType(query)
 	// Use admin API if DDL statement is provided.
 	if statementInfo.statementType == statementTypeDdl {
 		// Spanner does not support DDL in transactions, and although it is technically possible to execute DDL
@@ -820,7 +821,7 @@ func (c *conn) execContext(ctx context.Context, query string, execOptions ExecOp
 		return c.execDDL(ctx, spanner.NewStatement(query))
 	}
 
-	ss, err := prepareSpannerStmt(query, args)
+	ss, err := prepareSpannerStmt(c.parser, query, args)
 	if err != nil {
 		return nil, err
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -533,7 +534,12 @@ func TestConn_StartBatchDml(t *testing.T) {
 }
 
 func TestConn_NonDdlStatementsInDdlBatch(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser:            parser,
 		logger:            noopLogger,
 		autocommitDMLMode: Transactional,
 		batch:             &batch{tp: ddl},
@@ -568,7 +574,12 @@ func TestConn_NonDdlStatementsInDdlBatch(t *testing.T) {
 }
 
 func TestConn_NonDmlStatementsInDmlBatch(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser: parser,
 		logger: noopLogger,
 		batch:  &batch{tp: dml},
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
@@ -605,8 +616,12 @@ func TestConn_NonDmlStatementsInDmlBatch(t *testing.T) {
 func TestConn_GetBatchedStatements(t *testing.T) {
 	t.Parallel()
 
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
-	c := &conn{logger: noopLogger}
+	c := &conn{logger: noopLogger, parser: parser}
 	if !reflect.DeepEqual(c.GetBatchedStatements(), []spanner.Statement{}) {
 		t.Fatal("conn should return an empty slice when no batch is active")
 	}
@@ -649,8 +664,13 @@ func TestConn_GetBatchedStatements(t *testing.T) {
 }
 
 func TestConn_GetCommitTimestampAfterAutocommitDml(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := time.Now()
 	c := &conn{
+		parser:            parser,
 		logger:            noopLogger,
 		autocommitDMLMode: Transactional,
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
@@ -677,7 +697,12 @@ func TestConn_GetCommitTimestampAfterAutocommitDml(t *testing.T) {
 }
 
 func TestConn_GetCommitTimestampAfterAutocommitQuery(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser: parser,
 		logger: noopLogger,
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
 			return &spanner.RowIterator{}
@@ -693,7 +718,7 @@ func TestConn_GetCommitTimestampAfterAutocommitQuery(t *testing.T) {
 	if _, err := c.QueryContext(ctx, "SELECT * FROM Foo", []driver.NamedValue{}); err != nil {
 		t.Fatalf("failed to execute query: %v", err)
 	}
-	_, err := c.CommitTimestamp()
+	_, err = c.CommitTimestamp()
 	if g, w := spanner.ErrCode(err), codes.FailedPrecondition; g != w {
 		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 	}

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -3604,6 +3604,9 @@ func TestTag_RunTransaction_Retry(t *testing.T) {
 
 	conn, err := db.Conn(ctx)
 	defer func() {
+		if conn == nil {
+			return
+		}
 		if err := conn.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -4477,6 +4480,73 @@ func TestCustomClientConfig(t *testing.T) {
 	}
 }
 
+func TestPostgreSQLDialect(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnectionWithDialect(t, databasepb.DatabaseDialect_POSTGRESQL)
+	defer teardown()
+	_ = server.TestSpanner.PutStatementResult(
+		"SELECT * FROM Test WHERE Id=$1",
+		&testutil.StatementResult{
+			Type:      testutil.StatementResultResultSet,
+			ResultSet: testutil.CreateSelect1ResultSet(),
+		},
+	)
+
+	// The positional query parameter should be replaced with a PostgreSQL-style parameter.
+	stmt, err := db.Prepare("SELECT * FROM Test WHERE Id=?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for want := int64(1); rows.Next(); want++ {
+		var got int64
+		err = rows.Scan(&got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("value mismatch\n Got: %v\nWant: %v", got, want)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+	requests := drainRequestsFromServer(server.TestSpanner)
+	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	if g, w := len(sqlRequests), 1; g != w {
+		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	req := sqlRequests[0].(*sppb.ExecuteSqlRequest)
+	if g, w := len(req.ParamTypes), 1; g != w {
+		t.Fatalf("param types length mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if pt, ok := req.ParamTypes["p1"]; ok {
+		if g, w := pt.Code, sppb.TypeCode_INT64; g != w {
+			t.Fatalf("param type mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	} else {
+		t.Fatalf("no param type found for $1")
+	}
+	if g, w := len(req.Params.Fields), 1; g != w {
+		t.Fatalf("params length mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if val, ok := req.Params.Fields["p1"]; ok {
+		if g, w := val.GetStringValue(), "1"; g != w {
+			t.Fatalf("param value mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	} else {
+		t.Fatalf("no value found for param $1")
+	}
+}
+
 func numeric(v string) big.Rat {
 	res, _ := big.NewRat(1, 1).SetString(v)
 	return *res
@@ -4514,8 +4584,16 @@ func setupTestDBConnection(t *testing.T) (db *sql.DB, server *testutil.MockedSpa
 	return setupTestDBConnectionWithParams(t, "")
 }
 
+func setupTestDBConnectionWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+	return setupTestDBConnectionWithParamsAndDialect(t, "", dialect)
+}
+
 func setupTestDBConnectionWithParams(t *testing.T, params string) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
-	server, _, serverTeardown := setupMockedTestServer(t)
+	return setupTestDBConnectionWithParamsAndDialect(t, params, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+}
+
+func setupTestDBConnectionWithParamsAndDialect(t *testing.T, params string, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+	server, _, serverTeardown := setupMockedTestServerWithDialect(t, dialect)
 	db, err := sql.Open(
 		"spanner",
 		fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true;%s", server.Address, params))
@@ -4573,12 +4651,22 @@ func setupMockedTestServer(t *testing.T) (server *testutil.MockedSpannerInMemTes
 	return setupMockedTestServerWithConfig(t, spanner.ClientConfig{})
 }
 
+func setupMockedTestServerWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, spanner.ClientConfig{}, []option.ClientOption{}, dialect)
+}
+
 func setupMockedTestServerWithConfig(t *testing.T, config spanner.ClientConfig) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfigAndClientOptions(t, config, []option.ClientOption{})
 }
 
 func setupMockedTestServerWithConfigAndClientOptions(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, config, clientOptions, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+}
+
+func setupMockedTestServerWithConfigAndClientOptionsAndDialect(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	server, opts, serverTeardown := testutil.NewMockedSpannerInMemTestServer(t)
+	server.SetupSelectDialectResult(dialect)
+
 	opts = append(opts, clientOptions...)
 	ctx := context.Background()
 	formattedDatabase := fmt.Sprintf("projects/%s/instances/%s/databases/%s", "[PROJECT]", "[INSTANCE]", "[DATABASE]")

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -862,6 +862,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.2
+	github.com/hashicorp/golang-lru v0.5.1
 	google.golang.org/api v0.233.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237
 	google.golang.org/grpc v1.72.1

--- a/go.sum
+++ b/go.sum
@@ -828,6 +828,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/integration_test.go
+++ b/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -153,6 +154,10 @@ func initTestInstance(config string) (cleanup func(), err error) {
 }
 
 func createTestDB(ctx context.Context, statements ...string) (dsn string, cleanup func(), err error) {
+	return createTestDBWithDialect(ctx, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, statements...)
+}
+
+func createTestDBWithDialect(ctx context.Context, dialect databasepb.DatabaseDialect, statements ...string) (dsn string, cleanup func(), err error) {
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
 		return "", nil, err
@@ -169,11 +174,24 @@ func createTestDB(ctx context.Context, statements ...string) (dsn string, cleanu
 	}
 
 	databaseId := fmt.Sprintf("%s-%x", prefix, uniqueid)
-	opDB, err := databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
-		Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
-		CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", databaseId),
-		ExtraStatements: statements,
-	})
+	var opDB *database.CreateDatabaseOperation
+	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
+		if len(statements) > 0 {
+			return "", nil, errors.New("PostgreSQL does not allow extra statements in the CREATE DATABASE call")
+		}
+		opDB, err = databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+			Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
+			CreateStatement: fmt.Sprintf(`CREATE DATABASE "%s"`, databaseId),
+			DatabaseDialect: dialect,
+		})
+	} else {
+		opDB, err = databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+			Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
+			CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", databaseId),
+			ExtraStatements: statements,
+			DatabaseDialect: dialect,
+		})
+	}
 	if err != nil {
 		return "", nil, err
 	} else {
@@ -2339,6 +2357,38 @@ func TestCanRetryTransaction(t *testing.T) {
 		if !withInternalRetries && !aborted {
 			t.Fatalf("missing aborted error with internal retries disabled")
 		}
+	}
+}
+
+func TestPostgreSQL(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	// Create test database.
+	ctx := context.Background()
+	dsn, cleanup, err := createTestDBWithDialect(ctx, databasepb.DatabaseDialect_POSTGRESQL)
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer cleanup()
+	// Open db.
+	db, err := sql.Open("spanner", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx, "create table test (id bigint primary key, value varchar)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err = db.ExecContext(ctx, `INSERT INTO test (id, value) values ($1, $2)`, 1, "One"); err != nil {
+		t.Fatalf("failed to insert row: %v", err)
+	}
+
+	row := db.QueryRowContext(ctx, "select value from test where id=?", 1)
+	var val string
+	if err := row.Scan(&val); err != nil {
+		t.Fatalf("failed to scan row: %v", err)
 	}
 }
 

--- a/snippets/go.mod
+++ b/snippets/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/snippets/go.sum
+++ b/snippets/go.sum
@@ -862,6 +862,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/statement_parser_test.go
+++ b/statement_parser_test.go
@@ -15,9 +15,11 @@
 package spannerdriver
 
 import (
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -354,8 +356,12 @@ SELECT 1`,
 			want: `SELECT 1`,
 		},
 	}
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range tests {
-		got, err := removeCommentsAndTrim(tc.input)
+		got, err := parser.removeCommentsAndTrim(tc.input)
 		if err != nil && !tc.wantErr {
 			t.Error(err)
 			continue
@@ -472,8 +478,12 @@ SELECT SchoolID FROM Roster`,
 			want:  "\xb0\xb0\xb0\x80SELECT",
 		},
 	}
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range tests {
-		got := removeStatementHint(tc.input)
+		got := parser.removeStatementHint(tc.input)
 		if got != tc.want {
 			t.Errorf("removeStatementHint result mismatch\nGot: %q\nWant: %q", got, tc.want)
 		}
@@ -486,223 +496,837 @@ func FuzzRemoveCommentsAndTrim(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, input string) {
-		_, _ = removeCommentsAndTrim(input)
+		parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = parser.removeCommentsAndTrim(input)
+
+		parser, err = newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = parser.removeCommentsAndTrim(input)
 	})
 }
 
 func TestFindParams(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
+		input   string
+		wantSQL map[databasepb.DatabaseDialect]string
+		want    map[databasepb.DatabaseDialect][]string
+		wantErr map[databasepb.DatabaseDialect]error
+	}{
+		"id=@id": {
+			input: `SELECT * FROM PersonsTable WHERE id=@id`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM PersonsTable WHERE id=@id`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id"},
+			},
+		},
+		"simple multi-line comment": {
+			input: `/* comment */ SELECT * FROM PersonsTable WHERE id=@id`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `/* comment */ SELECT * FROM PersonsTable WHERE id=@id`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id"},
+			},
+		},
+		"simple single-line comment": {
+			input: `-- comment
+SELECT * FROM PersonsTable WHERE id=@id`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `-- comment
+SELECT * FROM PersonsTable WHERE id=@id`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id"},
+			},
+		},
+		"single-line hash comment with potential query parameter": {
+			input: `# This is not a @param in GoogleSQL, but it is in PostgreSQL
+SELECT * FROM PersonsTable WHERE id=@id`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `# This is not a @param in GoogleSQL, but it is in PostgreSQL
+SELECT * FROM PersonsTable WHERE id=@id`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"id"},
+				databasepb.DatabaseDialect_POSTGRESQL:          {"param", "id"},
+			},
+		},
+		"commented where clause": {
+			input: `SELECT * FROM PersonsTable WHERE id=@id /* and value=@value */`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM PersonsTable WHERE id=@id /* and value=@value */`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id"},
+			},
+		},
+		"id=@id and name=@name": {
+			input: `SELECT * FROM PersonsTable WHERE id=@id AND name=@name`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM PersonsTable WHERE id=@id AND name=@name`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id", "name"},
+			},
+		},
+		"id=@id and email literal": {
+			input: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"name"},
+			},
+		},
+		"multibyte character in string literal": {
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			input: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='@test.com'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='@test.com'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"name"},
+			},
+		},
+		"multibyte character in comment": {
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			input: `/*  */SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `/*  */SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"name"},
+			},
+		},
+		"table name with @": {
+			input: `SELECT * FROM """strange
+		@table
+		""" WHERE Name like @name AND Email='test@test.com'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `SELECT * FROM """strange
+		@table
+		""" WHERE Name like @name AND Email='test@test.com'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"name"},
+			},
+		},
+		"statement hint": {
+			input: `@{JOIN_METHOD=HASH_JOIN} SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `@{JOIN_METHOD=HASH_JOIN} SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"name"},
+			},
+		},
+		"multiple parameters": {
+			input: "INSERT INTO Foo (Col1, Col2, Col3) VALUES (@param1, @param2, @param3)",
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "INSERT INTO Foo (Col1, Col2, Col3) VALUES (@param1, @param2, @param3)",
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"param1", "param2", "param3"},
+			},
+		},
+		"force index hint with quoted index name": {
+			input: "SELECT * FROM PersonsTable@{FORCE_INDEX=`my_index`} WHERE id=@id AND name=@name",
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "SELECT * FROM PersonsTable@{FORCE_INDEX=`my_index`} WHERE id=@id AND name=@name",
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id", "name"},
+			},
+		},
+		"force index hint": {
+			input: "SELECT * FROM PersonsTable @{FORCE_INDEX=my_index} WHERE id=@id AND name=@name",
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "SELECT * FROM PersonsTable @{FORCE_INDEX=my_index} WHERE id=@id AND name=@name",
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"id", "name"},
+			},
+		},
+		"positional parameter": {
+			input: `SELECT * FROM PersonsTable WHERE id=?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `SELECT * FROM PersonsTable WHERE id=@p1`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `SELECT * FROM PersonsTable WHERE id=$1`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1"},
+			},
+		},
+		"two positional parameters and string literal with question marks": {
+			input: `?'?test?"?test?"?'?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'?test?"?test?"?'@p2`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `$1'?test?"?test?"?'$2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2"},
+			},
+		},
+		"two positional parameters and string literal with escaped quote": {
+			input: `?'?it\'?s'?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'?it\'?s'@p2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_POSTGRESQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\'?s'?`)),
+			},
+		},
+		"two positional parameters and string literal with escaped double quote": {
+			input: `?'?it\"?s'?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'?it\"?s'@p2`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `$1'?it\"?s'$2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2"},
+			},
+		},
+		"two positional parameters and double quoted string literal with escaped quote": {
+			input: `?"?it\"?s"?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1"?it\"?s"@p2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_POSTGRESQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?"?it\"?s"?`)),
+			},
+		},
+		"triple-quoted string": {
+			input: `?'''?it\'?s'''?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				// In GoogleSQL, the triple-quoted string means that single quotes are allowed inside the string.
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'''?it\'?s'''@p2`,
+				// In PostgreSQL, triple-quoted strings are not a thing. Instead, the ''' sequence starts a new string
+				// literal where the first character is a single quote. This means that the string ?'''?it\'?s'''?
+				// in PostgreSQL is invalid, because it consists of these parts:
+				// ?   '''?it\'   ?s'''?
+				// The first part is a query parameter.
+				// The second part is a string where the first character is a single quote. The last character is a
+				// backslash (which has no special meaning in a normal PostgreSQL string).
+				// The third part is invalid, as it contains an unclosed string literal.
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_POSTGRESQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'''?it\'?s'''?`)),
+			},
+		},
+		"triple-quoted string using double quotes": {
+			input: `?"""?it\"?s"""?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1"""?it\"?s"""@p2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_POSTGRESQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?"""?it\"?s"""?`)),
+			},
+		},
+		"backtick string with escaped quote": {
+			input: `?` + "`?it" + `\` + "`?s`" + `?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1` + "`?it" + `\` + "`?s`" + `@p2`,
+				// Backticks are not valid quotes in PostgreSQL, so these are just ignored.
+				databasepb.DatabaseDialect_POSTGRESQL: `$1` + "`$2it" + `\` + "`$3s`" + `$4`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+				databasepb.DatabaseDialect_POSTGRESQL:          {"p1", "p2", "p3", "p4"},
+			},
+		},
+		"triple-quoted string with escaped quote and linefeed": {
+			input: `?'''?it\'?s
+					?it\'?s'''?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'''?it\'?s
+					?it\'?s'''@p2`,
+				databasepb.DatabaseDialect_POSTGRESQL: `$1'''?it\'$2s
+					$3it\'?s'''$4`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+				databasepb.DatabaseDialect_POSTGRESQL:          {"p1", "p2", "p3", "p4"},
+			},
+		},
+		"triple-quoted string with escaped quote and linefeed (2)": {
+			input: `?'''?it\'?s
+					?it\'?s'''?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `@p1'''?it\'?s
+					?it\'?s'''@p2`,
+				databasepb.DatabaseDialect_POSTGRESQL: `$1'''?it\'$2s
+					$3it\'?s'''$4`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: {"p1", "p2"},
+				databasepb.DatabaseDialect_POSTGRESQL:          {"p1", "p2", "p3", "p4"},
+			},
+		},
+		"positional parameters in select and where clause": {
+			input: `select 1, ?, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=? and col2='test' and col3=? and col4='?' and col5="?" and col6='?''?''?'`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select 1, @p1, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=@p2 and col2='test' and col3=@p3 and col4='?' and col5="?" and col6='?''?''?'`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select 1, $1, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=$2 and col2='test' and col3=$3 and col4='?' and col5="?" and col6='?''?''?'`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2", "p3"},
+			},
+		},
+		"three positional parameters": {
+			input: `select * from foo where name=? and col2 like ? and col3 > ?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select * from foo where name=@p1 and col2 like @p2 and col3 > @p3`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select * from foo where name=$1 and col2 like $2 and col3 > $3`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2", "p3"},
+			},
+		},
+		"two positional parameters": {
+			input: `select * from foo where id between ? and ?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select * from foo where id between @p1 and @p2`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select * from foo where id between $1 and $2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2"},
+			},
+		},
+		"positional parameters in limit/offset": {
+			input: `select * from foo limit ? offset ?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select * from foo limit @p1 offset @p2`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select * from foo limit $1 offset $2`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2"},
+			},
+		},
+		"13 positional parameters": {
+			input: `select * from foo where col1=? and col2 like ? and col3 > ? and col4 < ? and col5 != ? and col6 not in (?, ?, ?) and col7 in (?, ?, ?) and col8 between ? and ?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select * from foo where col1=@p1 and col2 like @p2 and col3 > @p3 and col4 < @p4 and col5 != @p5 and col6 not in (@p6, @p7, @p8) and col7 in (@p9, @p10, @p11) and col8 between @p12 and @p13`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select * from foo where col1=$1 and col2 like $2 and col3 > $3 and col4 < $4 and col5 != $5 and col6 not in ($6, $7, $8) and col7 in ($9, $10, $11) and col8 between $12 and $13`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13"},
+			},
+		},
+		"positional parameter compared to string literal with potential named parameter": {
+			input: `select * from foo where ?='''strange @table'''`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `select * from foo where @p1='''strange @table'''`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `select * from foo where $1='''strange @table'''`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {"p1"},
+			},
+		},
+		"incomplete named parameter": {
+			input: `select foo from bar where id=@ order by value`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `select foo from bar where id=@ order by value`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: {},
+			},
+		},
+		"unclosed literal 1": {
+			input: `?'?it\'?s
+		?it\'?s'?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_POSTGRESQL: `$1'?it\'$2s
+		$3it\'?s'$4`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_POSTGRESQL: {"p1", "p2", "p3", "p4"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\'?s
+		?it\'?s'?`)),
+			},
+		},
+		"unclosed literal 2": {
+			input: `?'?it\'?s
+		?it\'?s?`,
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\'?s
+		?it\'?s?`)),
+			},
+		},
+		"unclosed literal 3": {
+			input: `?'''?it\'?s
+		?it\'?s'?`,
+			wantSQL: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_POSTGRESQL: `$1'''?it\'$2s
+		$3it\'?s'$4`,
+			},
+			want: map[databasepb.DatabaseDialect][]string{
+				databasepb.DatabaseDialect_POSTGRESQL: {"p1", "p2", "p3", "p4"},
+			},
+			wantErr: map[databasepb.DatabaseDialect]error{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'''?it\'?s
+		?it\'?s'?`)),
+			},
+		},
+	}
+	for _, dialect := range []databasepb.DatabaseDialect{databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, databasepb.DatabaseDialect_POSTGRESQL} {
+		parser, err := newStatementParser(dialect, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				sql := tc.input
+				gotSQL, got, err := parser.parseParameters(sql)
+				wantErr := expectedTestValue(dialect, tc.wantErr)
+				if err != nil && wantErr == nil {
+					t.Error(err)
+				}
+				if wantErr != nil {
+					if err == nil {
+						t.Errorf("missing expected error for %q", tc.input)
+					} else if !cmp.Equal(err.Error(), wantErr.Error()) {
+						t.Errorf("parseParameters error mismatch\nGot: %s\nWant: %s", err.Error(), wantErr)
+					}
+				}
+				want := expectedTestValue(dialect, tc.want)
+				if !cmp.Equal(got, want) {
+					t.Errorf("%v: parseParameters result mismatch\n Got: %s\nWant: %s", dialect, got, want)
+				}
+				wantSQL := expectedTestValue(dialect, tc.wantSQL)
+				if !cmp.Equal(gotSQL, wantSQL) {
+					t.Errorf("%v: parseParameters sql mismatch\n Got: %s\nWant: %s", dialect, gotSQL, wantSQL)
+				}
+			})
+		}
+	}
+}
+
+func TestFindParamsPostgreSQL(t *testing.T) {
+	tests := map[string]struct {
 		input   string
 		wantSQL string
 		want    []string
 		wantErr error
 	}{
-		{
-			input:   `SELECT * FROM PersonsTable WHERE id=@id`,
-			wantSQL: `SELECT * FROM PersonsTable WHERE id=@id`,
-			want:    []string{"id"},
-		},
-		{
-			input:   `/* comment */ SELECT * FROM PersonsTable WHERE id=@id`,
-			wantSQL: `/* comment */ SELECT * FROM PersonsTable WHERE id=@id`,
-			want:    []string{"id"},
-		},
-		{
-			input: `-- comment
-SELECT * FROM PersonsTable WHERE id=@id`,
-			wantSQL: `-- comment
-SELECT * FROM PersonsTable WHERE id=@id`,
-			want: []string{"id"},
-		},
-		{
-			input:   `SELECT * FROM PersonsTable WHERE id=@id /* and value=@value */`,
-			wantSQL: `SELECT * FROM PersonsTable WHERE id=@id /* and value=@value */`,
-			want:    []string{"id"},
-		},
-		{
-			input:   `SELECT * FROM PersonsTable WHERE id=@id AND name=@name`,
-			wantSQL: `SELECT * FROM PersonsTable WHERE id=@id AND name=@name`,
-			want:    []string{"id", "name"},
-		},
-		{
-			input:   `SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			wantSQL: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			want:    []string{"name"},
-		},
-		{
-			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
-			input: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='@test.com'`,
-			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
-			wantSQL: `SELECT * FROM PersonsTable WHERE Name like @name AND Email='@test.com'`,
-			want:    []string{"name"},
-		},
-		{
-			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
-			input: `/*  */SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
-			wantSQL: `/*  */SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			want:    []string{"name"},
-		},
-		{
-			input: `SELECT * FROM """strange
-		@table
-		""" WHERE Name like @name AND Email='test@test.com'`,
-			wantSQL: `SELECT * FROM """strange
-		@table
-		""" WHERE Name like @name AND Email='test@test.com'`,
-			want: []string{"name"},
-		},
-		{
-			input:   `@{JOIN_METHOD=HASH_JOIN} SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			wantSQL: `@{JOIN_METHOD=HASH_JOIN} SELECT * FROM PersonsTable WHERE Name like @name AND Email='test@test.com'`,
-			want:    []string{"name"},
-		},
-		{
-			input:   "INSERT INTO Foo (Col1, Col2, Col3) VALUES (@param1, @param2, @param3)",
-			wantSQL: "INSERT INTO Foo (Col1, Col2, Col3) VALUES (@param1, @param2, @param3)",
-			want:    []string{"param1", "param2", "param3"},
-		},
-		{
-			input:   "SELECT * FROM PersonsTable@{FORCE_INDEX=`my_index`} WHERE id=@id AND name=@name",
-			wantSQL: "SELECT * FROM PersonsTable@{FORCE_INDEX=`my_index`} WHERE id=@id AND name=@name",
-			want:    []string{"id", "name"},
-		},
-		{
-			input:   "SELECT * FROM PersonsTable @{FORCE_INDEX=my_index} WHERE id=@id AND name=@name",
-			wantSQL: "SELECT * FROM PersonsTable @{FORCE_INDEX=my_index} WHERE id=@id AND name=@name",
-			want:    []string{"id", "name"},
-		},
-		{
-			input:   `SELECT * FROM PersonsTable WHERE id=?`,
-			wantSQL: `SELECT * FROM PersonsTable WHERE id=@p1`,
+		"id=$1": {
+			input:   `SELECT * FROM PersonsTable WHERE id=$1`,
+			wantSQL: `SELECT * FROM PersonsTable WHERE id=$1`,
 			want:    []string{"p1"},
 		},
-		{
+		"simple multi-line comment": {
+			input:   `/* comment */ SELECT * FROM PersonsTable WHERE id=$1`,
+			wantSQL: `/* comment */ SELECT * FROM PersonsTable WHERE id=$1`,
+			want:    []string{"p1"},
+		},
+		"simple single-line comment": {
+			input: `-- comment
+SELECT * FROM PersonsTable WHERE id=$1`,
+			wantSQL: `-- comment
+SELECT * FROM PersonsTable WHERE id=$1`,
+			want: []string{"p1"},
+		},
+		"single-line hash comment with potential query parameter": {
+			input: `# This is not a comment, so this is a param $1
+		SELECT * FROM PersonsTable WHERE id=$2`,
+			wantSQL: `# This is not a comment, so this is a param $1
+		SELECT * FROM PersonsTable WHERE id=$2`,
+			want: []string{"p1", "p2"},
+		},
+		"commented where clause": {
+			input:   `SELECT * FROM PersonsTable WHERE id=$1 /* and value=$2 */`,
+			wantSQL: `SELECT * FROM PersonsTable WHERE id=$1 /* and value=$2 */`,
+			want:    []string{"p1"},
+		},
+		"id=$1 and name=$2": {
+			input:   `SELECT * FROM PersonsTable WHERE id=$1 AND name=$2`,
+			wantSQL: `SELECT * FROM PersonsTable WHERE id=$1 AND name=$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"id=$1 and email literal": {
+			input:   `SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			wantSQL: `SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			want:    []string{"p1"},
+		},
+		"multibyte character in string literal": {
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			input: `SELECT * FROM PersonsTable WHERE Name like $1 AND Email='@test.com'`,
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			wantSQL: `SELECT * FROM PersonsTable WHERE Name like $1 AND Email='@test.com'`,
+			want:    []string{"p1"},
+		},
+		"multibyte character in comment": {
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			input: `/*  */SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			//lint:ignore ST1018 allow control characters to verify the correct behavior of multibyte chars.
+			wantSQL: `/*  */SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			want:    []string{"p1"},
+		},
+		"table name with @": {
+			input: `SELECT * FROM """strange
+				@table
+				""" WHERE Name like $1 AND Email='test@test.com'`,
+			wantSQL: `SELECT * FROM """strange
+				@table
+				""" WHERE Name like $1 AND Email='test@test.com'`,
+			want: []string{"p1"},
+		},
+		"statement hint": {
+			input:   `/*@{JOIN_METHOD=HASH_JOIN}*/ SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			wantSQL: `/*@{JOIN_METHOD=HASH_JOIN}*/ SELECT * FROM PersonsTable WHERE Name like $1 AND Email='test@test.com'`,
+			want:    []string{"p1"},
+		},
+		"multiple parameters": {
+			input:   "INSERT INTO Foo (Col1, Col2, Col3) VALUES ($1, $2, $3)",
+			wantSQL: "INSERT INTO Foo (Col1, Col2, Col3) VALUES ($1, $2, $3)",
+			want:    []string{"p1", "p2", "p3"},
+		},
+		"force index hint with quoted index name": {
+			input:   "SELECT * FROM PersonsTable/*@{FORCE_INDEX=`my_index`}*/ WHERE id=$1 AND name=$2",
+			wantSQL: "SELECT * FROM PersonsTable/*@{FORCE_INDEX=`my_index`}*/ WHERE id=$1 AND name=$2",
+			want:    []string{"p1", "p2"},
+		},
+		"force index hint": {
+			input:   "SELECT * FROM PersonsTable /*@{FORCE_INDEX=my_index}*/ WHERE id=$1 AND name=$2",
+			wantSQL: "SELECT * FROM PersonsTable /*@{FORCE_INDEX=my_index}*/ WHERE id=$1 AND name=$2",
+			want:    []string{"p1", "p2"},
+		},
+		"positional parameter": {
+			input:   `SELECT * FROM PersonsTable WHERE id=?`,
+			wantSQL: `SELECT * FROM PersonsTable WHERE id=$1`,
+			want:    []string{"p1"},
+		},
+		"two positional parameters and string literal with question marks": {
 			input:   `?'?test?"?test?"?'?`,
-			wantSQL: `@p1'?test?"?test?"?'@p2`,
+			wantSQL: `$1'?test?"?test?"?'$2`,
 			want:    []string{"p1", "p2"},
 		},
-		{
+		"two positional parameters and string literal with escaped quote": {
 			input:   `?'?it\'?s'?`,
-			wantSQL: `@p1'?it\'?s'@p2`,
-			want:    []string{"p1", "p2"},
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\'?s'?`)),
 		},
-		{
+		"two positional parameters and string literal with escaped double quote": {
 			input:   `?'?it\"?s'?`,
-			wantSQL: `@p1'?it\"?s'@p2`,
+			wantSQL: `$1'?it\"?s'$2`,
 			want:    []string{"p1", "p2"},
 		},
-		{
+		"two positional parameters and double quoted string literal with escaped quote": {
 			input:   `?"?it\"?s"?`,
-			wantSQL: `@p1"?it\"?s"@p2`,
-			want:    []string{"p1", "p2"},
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?"?it\"?s"?`)),
 		},
-		{
+		"triple-quoted string": {
 			input:   `?'''?it\'?s'''?`,
-			wantSQL: `@p1'''?it\'?s'''@p2`,
-			want:    []string{"p1", "p2"},
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'''?it\'?s'''?`)),
 		},
-		{
+		"triple-quoted string using double quotes": {
 			input:   `?"""?it\"?s"""?`,
-			wantSQL: `@p1"""?it\"?s"""@p2`,
-			want:    []string{"p1", "p2"},
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?"""?it\"?s"""?`)),
 		},
-		{
+		"backtick string with escaped quote": {
 			input:   `?` + "`?it" + `\` + "`?s`" + `?`,
-			wantSQL: `@p1` + "`?it" + `\` + "`?s`" + `@p2`,
-			want:    []string{"p1", "p2"},
+			wantSQL: `$1` + "`$2it" + `\` + "`$3s`" + `$4`,
+			want:    []string{"p1", "p2", "p3", "p4"},
 		},
-		{
+		"triple-quoted string with escaped quote and linefeed": {
 			input: `?'''?it\'?s
-		?it\'?s'''?`,
-			wantSQL: `@p1'''?it\'?s
-		?it\'?s'''@p2`,
-			want: []string{"p1", "p2"},
+				?it\'?s'''?`,
+			wantSQL: `$1'''?it\'$2s
+				$3it\'?s'''$4`,
+			want: []string{"p1", "p2", "p3", "p4"},
 		},
-		{
+		"triple-quoted string with escaped quote and linefeed (2)": {
 			input: `?'''?it\'?s
-		?it\'?s'''?`,
-			wantSQL: `@p1'''?it\'?s
-		?it\'?s'''@p2`,
-			want: []string{"p1", "p2"},
+				?it\'?s'''?`,
+			wantSQL: `$1'''?it\'$2s
+				$3it\'?s'''$4`,
+			want: []string{"p1", "p2", "p3", "p4"},
 		},
-		{
+		"positional parameters in select and where clause": {
 			input:   `select 1, ?, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=? and col2='test' and col3=? and col4='?' and col5="?" and col6='?''?''?'`,
-			wantSQL: `select 1, @p1, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=@p2 and col2='test' and col3=@p3 and col4='?' and col5="?" and col6='?''?''?'`,
+			wantSQL: `select 1, $1, 'test?test', "test?test", foo.* from` + "`foo`" + `where col1=$2 and col2='test' and col3=$3 and col4='?' and col5="?" and col6='?''?''?'`,
 			want:    []string{"p1", "p2", "p3"},
 		},
-		{
+		"three positional parameters": {
 			input:   `select * from foo where name=? and col2 like ? and col3 > ?`,
-			wantSQL: `select * from foo where name=@p1 and col2 like @p2 and col3 > @p3`,
+			wantSQL: `select * from foo where name=$1 and col2 like $2 and col3 > $3`,
 			want:    []string{"p1", "p2", "p3"},
 		},
-		{
+		"two positional parameters": {
 			input:   `select * from foo where id between ? and ?`,
-			wantSQL: `select * from foo where id between @p1 and @p2`,
+			wantSQL: `select * from foo where id between $1 and $2`,
 			want:    []string{"p1", "p2"},
 		},
-		{
+		"positional parameters in limit/offset": {
 			input:   `select * from foo limit ? offset ?`,
-			wantSQL: `select * from foo limit @p1 offset @p2`,
+			wantSQL: `select * from foo limit $1 offset $2`,
 			want:    []string{"p1", "p2"},
 		},
-		{
+		"13 positional parameters": {
 			input:   `select * from foo where col1=? and col2 like ? and col3 > ? and col4 < ? and col5 != ? and col6 not in (?, ?, ?) and col7 in (?, ?, ?) and col8 between ? and ?`,
-			wantSQL: `select * from foo where col1=@p1 and col2 like @p2 and col3 > @p3 and col4 < @p4 and col5 != @p5 and col6 not in (@p6, @p7, @p8) and col7 in (@p9, @p10, @p11) and col8 between @p12 and @p13`,
+			wantSQL: `select * from foo where col1=$1 and col2 like $2 and col3 > $3 and col4 < $4 and col5 != $5 and col6 not in ($6, $7, $8) and col7 in ($9, $10, $11) and col8 between $12 and $13`,
 			want:    []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13"},
 		},
-		{
-			input:   `select * from foo where ?='''strange @table'''`,
-			wantSQL: `select * from foo where @p1='''strange @table'''`,
+		"positional parameter compared to string literal with potential named parameter": {
+			input:   `select * from foo where ?='''strange $1table'''`,
+			wantSQL: `select * from foo where $1='''strange $1table'''`,
 			want:    []string{"p1"},
 		},
-		{
-			input:   `select foo from bar where id=@ order by value`,
-			wantSQL: `select foo from bar where id=@ order by value`,
+		"incomplete named parameter": {
+			input:   `select foo from bar where id=$ order by value`,
+			wantSQL: `select foo from bar where id=$ order by value`,
 			want:    []string{},
 		},
-		{
+		"unclosed literal 1": {
 			input: `?'?it\'?s
-		?it\'?s'?`,
-			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "statement contains an unclosed literal: %s", `?'?it\'?s
-		?it\'?s'?`)),
+				?it\'?s'?`,
+			wantSQL: `$1'?it\'$2s
+				$3it\'?s'$4`,
+			want: []string{"p1", "p2", "p3", "p4"},
 		},
-		{
+		"unclosed literal 2": {
 			input: `?'?it\'?s
-		?it\'?s?`,
-			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "statement contains an unclosed literal: %s", `?'?it\'?s
-		?it\'?s?`)),
+				?it\'?s?`,
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\'?s
+				?it\'?s?`)),
 		},
-		{
+		"unclosed literal 3": {
 			input: `?'''?it\'?s
-		?it\'?s'?`,
-			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "statement contains an unclosed literal: %s", `?'''?it\'?s
-		?it\'?s'?`)),
+				?it\'?s'?`,
+			wantSQL: `$1'''?it\'$2s
+				$3it\'?s'$4`,
+			want: []string{"p1", "p2", "p3", "p4"},
+		},
+		"dollar-quoted string": {
+			input:   `select foo from bar where id=$$this is a string$$ order by value`,
+			wantSQL: `select foo from bar where id=$$this is a string$$ order by value`,
+			want:    []string{},
+		},
+		"dollar-quoted string with tag": {
+			input:   `select foo from bar where id=$tag$this is a string$tag$ order by value`,
+			wantSQL: `select foo from bar where id=$tag$this is a string$tag$ order by value`,
+			want:    []string{},
+		},
+		"dollar-quoted string with tag and param": {
+			input:   `select foo from bar where id=$tag$this is a string$tag$ and value=? order by value`,
+			wantSQL: `select foo from bar where id=$tag$this is a string$tag$ and value=$1 order by value`,
+			want:    []string{"p1"},
+		},
+		"invalid dollar-quoted string": {
+			input: "select foo from bar where id=$tag$this is an invalid string and value=? order by value",
+			wantErr: spanner.ToSpannerError(
+				status.Errorf(codes.InvalidArgument,
+					"SQL statement contains an unclosed literal: %s",
+					"select foo from bar where id=$tag$this is an invalid string and value=? order by value")),
 		},
 	}
-	for _, tc := range tests {
-		sql := tc.input
-		gotSQL, got, err := parseParameters(sql)
-		if err != nil && tc.wantErr == nil {
-			t.Error(err)
-			continue
-		}
-		if tc.wantErr != nil {
-			if err == nil {
-				t.Errorf("missing expected error for %q", tc.input)
-				continue
+	parser, err := newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sql := tc.input
+			gotSQL, got, err := parser.parseParameters(sql)
+			if err != nil && tc.wantErr == nil {
+				t.Error(err)
 			}
-			if !cmp.Equal(err.Error(), tc.wantErr.Error()) {
-				t.Errorf("parseParameters error mismatch\nGot: %s\nWant: %s", err.Error(), tc.wantErr)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Errorf("missing expected error for %q", tc.input)
+				} else if !cmp.Equal(err.Error(), tc.wantErr.Error()) {
+					t.Errorf("parseParameters error mismatch\nGot: %s\nWant: %s", err.Error(), tc.wantErr)
+				}
 			}
-			continue
-		}
-		if !cmp.Equal(got, tc.want) {
-			t.Errorf("parseParameters result mismatch\n Got: %s\nWant: %s", got, tc.want)
-		}
-		if !cmp.Equal(gotSQL, tc.wantSQL) {
-			t.Errorf("parseParameters sql mismatch\n Got: %s\nWant: %s", gotSQL, tc.wantSQL)
-		}
+			want := tc.want
+			if !cmp.Equal(got, want) {
+				t.Errorf("parseParameters result mismatch\n Got: %s\nWant: %s", got, want)
+			}
+			if !cmp.Equal(gotSQL, tc.wantSQL) {
+				t.Errorf("parseParameters sql mismatch\n Got: %s\nWant: %s", gotSQL, tc.wantSQL)
+			}
+		})
+	}
+}
+
+func TestFindParamsWithCommentsPostgreSQL(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		wantSQL string
+		want    []string
+		wantErr error
+	}{
+		"name=?": {
+			input:   `select * %sfrom foo where name=?`,
+			wantSQL: `select * %sfrom foo where name=$1`,
+			want:    []string{"p1"},
+		},
+		"question marks in single-quoted string": {
+			input:   `?%s'?test?"?test?"?'?`,
+			wantSQL: `$1%s'?test?"?test?"?'$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"single quotes in single-quoted string": {
+			input:   `?'?it\''?s'%s?`,
+			wantSQL: `$1'?it\''?s'%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"backslash in single-quoted string": {
+			input:   `?'?it\\"?s'%s?`,
+			wantSQL: `$1'?it\\"?s'%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"backslash in double-quoted string": {
+			input:   `?\"?it\\"\"?s\"%s?`,
+			wantSQL: `$1\"?it\\"\"?s\"%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"triple-quotes": {
+			input:   `?%s'''?it\''?s'''?`,
+			wantSQL: `$1%s'''?it\''?s'''$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"triple-double-quotes": {
+			input:   `?"""?it\""?s"""%s?`,
+			wantSQL: `$1"""?it\""?s"""%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"dollar-quoted string": {
+			input:   `?$$?it$?s$$%s?`,
+			wantSQL: `$1$$?it$?s$$%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"dollar-quoted string with tag": {
+			input:   `?$tag$?it$?s$tag$%s?`,
+			wantSQL: `$1$tag$?it$?s$tag$%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"dollar-quoted string with linefeed": {
+			input: `?%s$$?it\'?s 
+?it\'?s$$?`,
+			wantSQL: `$1%s$$?it\'?s 
+?it\'?s$$$2`,
+			want: []string{"p1", "p2"},
+		},
+		"single-quoted string with linefeed": {
+			input: `?'?it\''?s 
+?it\''?s'%s?`,
+			wantSQL: `$1'?it\''?s 
+?it\''?s'%s$2`,
+			want: []string{"p1", "p2"},
+		},
+		"unclosed single-quoted string": {
+			input: `?'?it\''?s 
+?it\''?%s?`,
+			wantErr: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "SQL statement contains an unclosed literal: %s", `?'?it\''?s 
+?it\''?%s?`)),
+		},
+		"triple-quoted string with linefeed": {
+			input: `?%s'''?it\''?s 
+?it\''?s'?`,
+			wantSQL: `$1%s'''?it\''?s 
+?it\''?s'$2`,
+			want: []string{"p1", "p2"},
+		},
+		"multiple params": {
+			input:   `select 1, ?, 'test?test', "test?test", %sfoo.* from foo where col1=? and col2='test' and col3=? and col4='?' and col5="?" and col6='?''?''?'`,
+			wantSQL: `select 1, $1, 'test?test', "test?test", %sfoo.* from foo where col1=$2 and col2='test' and col3=$3 and col4='?' and col5="?" and col6='?''?''?'`,
+			want:    []string{"p1", "p2", "p3"},
+		},
+		"multiple params (2)": {
+			input:   `select * %sfrom foo where name=? and col2 like ? and col3 > ?`,
+			wantSQL: `select * %sfrom foo where name=$1 and col2 like $2 and col3 > $3`,
+			want:    []string{"p1", "p2", "p3"},
+		},
+		"comment right after param": {
+			input:   `select * from foo where id between ?%s and ?`,
+			wantSQL: `select * from foo where id between $1%s and $2`,
+			want:    []string{"p1", "p2"},
+		},
+		"comment between limit and offset": {
+			input:   `select * from foo limit ? %s offset ?`,
+			wantSQL: `select * from foo limit $1 %s offset $2`,
+			want:    []string{"p1", "p2"},
+		},
+		"comment in where clause": {
+			input: `select *
+					from foo
+					where col1=?
+					and col2 like ?
+					%s
+					and col3 > ?
+					and col4 < ?
+					and col5 != ?
+					and col6 not in (?, ?, ?)
+					and col7 in (?, ?, ?)
+					and col8 between ? and ?`,
+			wantSQL: `select *
+					from foo
+					where col1=$1
+					and col2 like $2
+					%s
+					and col3 > $3
+					and col4 < $4
+					and col5 != $5
+					and col6 not in ($6, $7, $8)
+					and col7 in ($9, $10, $11)
+					and col8 between $12 and $13`,
+			want: []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13"},
+		},
+	}
+
+	parser, err := newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, comment := range []string{
+				"-- test comment\n",
+				"/* another test comment */",
+				"/* comment\nwith\nmultiple\nlines\n */",
+				"/* comment /* with nested */ comment */",
+			} {
+				input := fmt.Sprintf(test.input, comment)
+				wantSQL := fmt.Sprintf(test.wantSQL, comment)
+				got, params, err := parser.findParams(input)
+				if err != nil && test.wantErr == nil {
+					t.Errorf("got unexpected error: %v", err)
+				} else if err != nil && test.wantErr != nil {
+					if g, w := spanner.ErrCode(err), spanner.ErrCode(test.wantErr); g != w {
+						t.Errorf("error code mismatch\n Got: %s\nWant: %s", g, w)
+					}
+				} else {
+					if !cmp.Equal(params, test.want) {
+						t.Errorf("parameters mismatch\n Got: %s\nWant: %s", params, test.want)
+					}
+					if got != wantSQL {
+						t.Errorf("SQL mismatch\n Got: %s\nWant: %s", got, wantSQL)
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -712,7 +1336,17 @@ func FuzzFindParams(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, input string) {
-		_, _, _ = parseParameters(input)
+		parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, _ = parser.parseParameters(input)
+
+		parser, err = newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, _ = parser.parseParameters(input)
 	})
 }
 
@@ -887,8 +1521,12 @@ func TestStatementIsDdl(t *testing.T) {
 		},
 	}
 
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range tests {
-		got := detectStatementType(tc.input).statementType == statementTypeDdl
+		got := parser.detectStatementType(tc.input).statementType == statementTypeDdl
 		if got != tc.want {
 			t.Errorf("isDDL test failed, %s: wanted %t got %t.", tc.name, tc.want, got)
 		}
@@ -900,8 +1538,12 @@ func FuzzIsDdl(f *testing.F) {
 		f.Add(sample)
 	}
 
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		f.Fatal(err)
+	}
 	f.Fuzz(func(t *testing.T, input string) {
-		_ = isDDL(input)
+		_ = parser.isDDL(input)
 	})
 }
 
@@ -971,30 +1613,39 @@ func TestParseClientSideStatement(t *testing.T) {
 		},
 	}
 
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range tests {
-		statement, err := parseClientSideStatement(&conn{logger: noopLogger}, tc.input)
-		if err != nil {
-			t.Fatalf("failed to parse statement %s: %v", tc.name, err)
-		}
-		if tc.exec && statement.execContext == nil {
-			t.Errorf("execContext missing for %q", tc.input)
-		}
-		if tc.query && statement.queryContext == nil {
-			t.Errorf("queryContext missing for %q", tc.input)
-		}
-
-		var got string
-		if statement != nil {
-			got = statement.Name
-		}
-		if got != tc.want {
-			t.Errorf("parseClientSideStatement test failed: %s\nGot: %s\nWant: %s.", tc.name, got, tc.want)
-		}
-		if tc.wantParams != "" {
-			if g, w := statement.params, tc.wantParams; g != w {
-				t.Errorf("params mismatch for %s\nGot: %v\nWant: %v", tc.name, g, w)
+		t.Run(tc.name, func(t *testing.T) {
+			statement, err := parser.parseClientSideStatement(&conn{logger: noopLogger, parser: parser}, tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse statement %s: %v", tc.name, err)
 			}
-		}
+			if statement == nil {
+				t.Fatalf("statement is not a client-side statement: %s", tc.input)
+			}
+			if tc.exec && statement.execContext == nil {
+				t.Errorf("execContext missing for %q", tc.input)
+			}
+			if tc.query && statement.queryContext == nil {
+				t.Errorf("queryContext missing for %q", tc.input)
+			}
+
+			var got string
+			if statement != nil {
+				got = statement.Name
+			}
+			if got != tc.want {
+				t.Errorf("parseClientSideStatement test failed: %s\nGot: %s\nWant: %s.", tc.name, got, tc.want)
+			}
+			if tc.wantParams != "" {
+				if g, w := statement.params, tc.wantParams; g != w {
+					t.Errorf("params mismatch for %s\nGot: %v\nWant: %v", tc.name, g, w)
+				}
+			}
+		})
 	}
 }
 
@@ -1004,209 +1655,388 @@ func FuzzParseClientSideStatement(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, input string) {
-		_, _ = parseClientSideStatement(&conn{logger: noopLogger}, input)
+		parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = parser.parseClientSideStatement(&conn{logger: noopLogger, parser: parser}, input)
 	})
 }
 
 func TestRemoveCommentsAndTrim_Errors(t *testing.T) {
-	_, err := removeCommentsAndTrim("SELECT 'Hello World FROM SomeTable")
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = parser.removeCommentsAndTrim("SELECT 'Hello World FROM SomeTable")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}
-	_, err = removeCommentsAndTrim("SELECT 'Hello World\nFROM SomeTable")
+	_, err = parser.removeCommentsAndTrim("SELECT 'Hello World\nFROM SomeTable")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}
 }
 
 func TestFindParams_Errors(t *testing.T) {
-	_, _, err := findParams("SELECT 'Hello World FROM SomeTable WHERE id=@id")
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = parser.findParams("SELECT 'Hello World FROM SomeTable WHERE id=@id")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}
-	_, _, err = findParams("SELECT 'Hello World\nFROM SomeTable WHERE id=@id")
+	_, _, err = parser.findParams("SELECT 'Hello World\nFROM SomeTable WHERE id=@id")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}
 }
 
-func TestSkip(t *testing.T) {
+func TestSkipWhitespaces(t *testing.T) {
 	tests := []struct {
-		input   string
-		pos     int
-		skipped string
-		invalid bool
+		name  string
+		input string
+		want  string
 	}{
 		{
-			input:   "",
-			skipped: "",
+			name:  "single space",
+			input: " ",
+			want:  " ",
 		},
 		{
-			input:   "1 ",
-			skipped: "1",
+			name:  "single linefeed",
+			input: "\n",
+			want:  "\n",
 		},
 		{
-			input:   "12 ",
-			skipped: "1",
+			name:  "single tab",
+			input: "\t",
+			want:  "\t",
 		},
 		{
-			input:   "12 ",
-			pos:     1,
-			skipped: "2",
+			name:  "multiple different spaces",
+			input: "\t   \n  \t",
+			want:  "\t   \n  \t",
 		},
 		{
-			input:   "12",
-			pos:     2,
-			skipped: "",
+			name:  "multiple different spaces followed by keyword",
+			input: "\t   \n  \tselect",
+			want:  "\t   \n  \t",
 		},
 		{
-			input:   "'foo'  ",
-			skipped: "'foo'",
+			name:  "keyword",
+			input: "select  ",
+			want:  "",
 		},
 		{
-			input:   "'foo''bar'  ",
-			skipped: "'foo'",
+			name:  "multi-byte token",
+			input: "ø",
+			want:  "",
 		},
 		{
-			input:   "'foo'  'bar'  ",
-			skipped: "'foo'",
-		},
-		{
-			input:   "'foo''bar'  ",
-			pos:     5,
-			skipped: "'bar'",
-		},
-		{
-			input:   `'foo"bar"'  `,
-			skipped: `'foo"bar"'`,
-		},
-		{
-			input:   `"foo'bar'"  `,
-			skipped: `"foo'bar'"`,
-		},
-		{
-			input:   "`foo'bar'`  ",
-			skipped: "`foo'bar'`",
-		},
-		{
-			input:   "'''foo'bar'''  ",
-			skipped: "'''foo'bar'''",
-		},
-		{
-			input:   "'''foo\\'bar'''  ",
-			skipped: "'''foo\\'bar'''",
-		},
-		{
-			input:   "'''foo\\'\\'bar'''  ",
-			skipped: "'''foo\\'\\'bar'''",
-		},
-		{
-			input:   "'''foo\\'\\'\\'bar'''  ",
-			skipped: "'''foo\\'\\'\\'bar'''",
-		},
-		{
-			input:   "```foo`bar```  ",
-			skipped: "```foo`bar```",
-		},
-		{
-			input:   `"""foo"bar"""  `,
-			skipped: `"""foo"bar"""`,
-		},
-		{
-			input:   "-- comment",
-			skipped: "-- comment",
-		},
-		{
-			input:   "-- comment\nselect * from foo",
-			skipped: "-- comment\n",
-		},
-		{
-			input:   "# comment",
-			skipped: "# comment",
-		},
-		{
-			input:   "# comment\nselect * from foo",
-			skipped: "# comment\n",
-		},
-		{
-			input:   "/* comment */",
-			skipped: "/* comment */",
-		},
-		{
-			input:   "/* comment */ select * from foo",
-			skipped: "/* comment */",
-		},
-		{
-			input:   "/* comment /* GoogleSQL does not support nested comments */ select * from foo",
-			skipped: "/* comment /* GoogleSQL does not support nested comments */",
-		},
-		{
-			// GoogleSQL does not support dollar-quoted strings.
-			input:   "$tag$not a string$tag$ select * from foo",
-			skipped: "$",
-		},
-		{
-			input:   "/* 'test' */ foo",
-			skipped: "/* 'test' */",
-		},
-		{
-			input:   "-- 'test' \n foo",
-			skipped: "-- 'test' \n",
-		},
-		{
-			input:   "'/* test */' foo",
-			skipped: "'/* test */'",
-		},
-		{
-			input:   "'foo\\''  ",
-			skipped: "'foo\\''",
-		},
-		{
-			input:   "r'foo\\''  ",
-			pos:     1,
-			skipped: "'foo\\''",
-		},
-		{
-			input:   "'''foo\\'\\'\\'bar'''  ",
-			skipped: "'''foo\\'\\'\\'bar'''",
-		},
-		{
-			input:   "'foo\n'  ",
-			invalid: true,
-		},
-		{
-			input:   "'''foo\n'''  ",
-			skipped: "'''foo\n'''",
-		},
-		{
-			input:   "'⌘'",
-			skipped: "'⌘'",
-		},
-		{
-			input:   "'€'",
-			skipped: "'€'",
-		},
-		{
-			input:   "'€ 100,-'  ",
-			skipped: "'€ 100,-'",
-		},
-		{
-			input:   "'𒀀'",
-			skipped: "'𒀀'",
+			name:  "multi-byte token after space",
+			input: " ø",
+			want:  " ",
 		},
 	}
-	for _, test := range tests {
-		pos, err := skip([]byte(test.input), test.pos)
-		if test.invalid && err == nil {
-			t.Errorf("missing expected error for %s", test.input)
-		} else if !test.invalid && err != nil {
-			t.Errorf("got unexpected error for %s: %v", test.input, err)
-		} else {
-			skipped := test.input[test.pos:pos]
-			if skipped != test.skipped {
-				t.Errorf("skipped mismatch\nGot:  %v\nWant: %v", skipped, test.skipped)
-			}
+	for _, dialect := range []databasepb.DatabaseDialect{
+		databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		databasepb.DatabaseDialect_POSTGRESQL,
+	} {
+		p, err := getStatementParser(dialect, 1000)
+		if err != nil {
+			t.Fatal(err)
 		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s: %s", dialect, test.name), func(t *testing.T) {
+				pos := p.skipWhitespaces([]byte(test.input), 0)
+				if g, w := test.input[:pos], test.want; g != w {
+					t.Errorf("skip whitespace mismatch\n Got: %q\nWant: %q", g, w)
+				}
+			})
+		}
+	}
+}
+
+func TestSkip(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		pos     int
+		skipped map[databasepb.DatabaseDialect]string
+		invalid map[databasepb.DatabaseDialect]bool
+	}{
+		"empty string": {
+			input:   "",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: ""},
+		},
+		"single digit": {
+			input:   "1 ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "1"},
+		},
+		"double digit": {
+			input:   "12 ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "1"},
+		},
+		"double digit, pos 1": {
+			input:   "12 ",
+			pos:     1,
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "2"},
+		},
+		"end of statement": {
+			input:   "12",
+			pos:     2,
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: ""},
+		},
+		"string": {
+			input:   "'foo'  ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'foo'"},
+		},
+		"two strings directly after each other": {
+			input: "'foo''bar'  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'foo'",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'foo''bar'",
+			},
+		},
+		"two strings with space between": {
+			input:   "'foo'  'bar'  ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'foo'"},
+		},
+		"two strings directly after each other, starting at second string": {
+			input:   "'foo''bar'  ",
+			pos:     5,
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'bar'"},
+		},
+		"string with quoted string inside": {
+			input:   `'foo"bar"'  `,
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `'foo"bar"'`},
+		},
+		"double-quoted string with string inside": {
+			input:   `"foo'bar'"  `,
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: `"foo'bar'"`},
+		},
+		"backtick string with string inside": {
+			input: "`foo'bar'`  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "`foo'bar'`",
+				databasepb.DatabaseDialect_POSTGRESQL:          "`",
+			},
+		},
+		"triple-quoted string with quote inside": {
+			input: "'''foo'bar'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'''foo'bar'''",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'''foo'",
+			},
+		},
+		"triple-quoted string with escaped quote inside": {
+			input: "'''foo\\'bar'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'''foo\\'bar'''",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'''foo\\'",
+			},
+		},
+		"triple-quoted string with two escaped quotes inside": {
+			input: "'''foo\\'\\'bar'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'''foo\\'\\'bar'''",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'''foo\\'",
+			},
+		},
+		"triple-quoted string with three escaped quotes inside": {
+			input: "'''foo\\'\\'\\'bar'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'''foo\\'\\'\\'bar'''",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'''foo\\'",
+			},
+		},
+		"triple-quoted backtick string with backtick inside": {
+			input: "```foo`bar```  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "```foo`bar```",
+				// Backticks are not valid quote characters in PostgreSQL, so only a single character is skipped.
+				databasepb.DatabaseDialect_POSTGRESQL: "`",
+			},
+		},
+		"triple-double quote string with double quote inside": {
+			input: `"""foo"bar"""  `,
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: `"""foo"bar"""`,
+				databasepb.DatabaseDialect_POSTGRESQL:          `"""foo"`,
+			},
+		},
+		"single line comment": {
+			input:   "-- comment",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "-- comment"},
+		},
+		"single line comment followed by select": {
+			input:   "-- comment\nselect * from foo",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "-- comment\n"},
+		},
+		"single line comment (#)": {
+			input: "# comment",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "# comment",
+				// PostgreSQL does not consider '#' to be the start of a single line comment.
+				databasepb.DatabaseDialect_POSTGRESQL: "#",
+			},
+		},
+		"single line comment (#) followed by select": {
+			input: "# comment\nselect * from foo",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "# comment\n",
+				// PostgreSQL does not consider '#' to be the start of a single line comment.
+				databasepb.DatabaseDialect_POSTGRESQL: "#",
+			},
+		},
+		"multi-line comment": {
+			input:   "/* comment */",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "/* comment */"},
+		},
+		"multi-line comment followed by select": {
+			input:   "/* comment */ select * from foo",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "/* comment */"},
+		},
+		"nested comment": {
+			input: "/* comment /* GoogleSQL does not support nested comments */ select * from foo",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "/* comment /* GoogleSQL does not support nested comments */",
+				databasepb.DatabaseDialect_POSTGRESQL:          "/* comment /* GoogleSQL does not support nested comments */ select * from foo",
+			},
+		},
+		"nested comment 2": {
+			input: "/* comment /* GoogleSQL does not support nested comments */ But PostgreSQL does support them */ select * from foo ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "/* comment /* GoogleSQL does not support nested comments */",
+				databasepb.DatabaseDialect_POSTGRESQL:          "/* comment /* GoogleSQL does not support nested comments */ But PostgreSQL does support them */",
+			},
+		},
+		"dollar-quoted string": {
+			// GoogleSQL does not support dollar-quoted strings.
+			input: "$tag$not a string in GoogleSQL$tag$ select * from foo",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "$",
+				databasepb.DatabaseDialect_POSTGRESQL:          "$tag$not a string in GoogleSQL$tag$",
+			},
+		},
+		"string in comment": {
+			input:   "/* 'test' */ foo",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "/* 'test' */"},
+		},
+		"string in single-line comment": {
+			input:   "-- 'test' \n foo",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "-- 'test' \n"},
+		},
+		"string in single-line comment (#)": {
+			input: "# 'test' \n foo",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "# 'test' \n",
+				databasepb.DatabaseDialect_POSTGRESQL:          "#",
+			},
+		},
+		"comment in string": {
+			input:   "'/* test */' foo",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'/* test */'"},
+		},
+		"escaped quote": {
+			input: "'foo\\''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'foo\\''",
+			},
+			invalid: map[databasepb.DatabaseDialect]bool{
+				// This is invalid for PostgreSQL, because:
+				// 1. The first 'foo\ part of the string is 'just a normal string'. The backslash has no special meaning.
+				// 2. The last part is two single quotes; In PostgreSQL, this is an escaped quote inside the string
+				// literal. This again means that this string literal is unclosed.
+				databasepb.DatabaseDialect_POSTGRESQL: true,
+			},
+		},
+		"escaped quote in raw string": {
+			input: "r'foo\\''  ",
+			pos:   1,
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'foo\\''",
+			},
+			invalid: map[databasepb.DatabaseDialect]bool{
+				// This is an unclosed literal in PostgreSQL
+				databasepb.DatabaseDialect_POSTGRESQL: true,
+			},
+		},
+		"escaped quotes in triple-quoted string": {
+			input: "'''foo\\'\\'\\'bar'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: "'''foo\\'\\'\\'bar'''",
+				databasepb.DatabaseDialect_POSTGRESQL:          "'''foo\\'",
+			},
+		},
+		"string with linefeed": {
+			input: "'foo\n'  ",
+			skipped: map[databasepb.DatabaseDialect]string{
+				databasepb.DatabaseDialect_POSTGRESQL: "'foo\n'",
+			},
+			invalid: map[databasepb.DatabaseDialect]bool{
+				databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL: true,
+			},
+		},
+		"triple-quoted string with linefeed": {
+			input:   "'''foo\n'''  ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'''foo\n'''"},
+		},
+		"multibyte character in string": {
+			input:   "'⌘'",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'⌘'"},
+		},
+		"multibyte character in string (2)": {
+			input:   "'€'",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'€'"},
+		},
+		"multibyte character in string (3)": {
+			input:   "'€ 100,-'  ",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'€ 100,-'"},
+		},
+		"multibyte character in string (4)": {
+			input:   "'𒀀'",
+			skipped: map[databasepb.DatabaseDialect]string{databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED: "'𒀀'"},
+		},
+	}
+	for _, dialect := range []databasepb.DatabaseDialect{databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, databasepb.DatabaseDialect_POSTGRESQL} {
+		parser, err := newStatementParser(dialect, 1000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name, test := range tests {
+			t.Run(fmt.Sprintf("Dialect: %v, test: %v", databasepb.DatabaseDialect_name[int32(dialect)], name), func(t *testing.T) {
+				pos, err := parser.skip([]byte(test.input), test.pos)
+				wantInvalid := expectedTestValue(dialect, test.invalid)
+				if wantInvalid && err == nil {
+					t.Errorf("missing expected error for %s", test.input)
+				} else if !wantInvalid && err != nil {
+					t.Errorf("got unexpected error for %s: %v", test.input, err)
+				} else if !wantInvalid {
+					skipped := test.input[test.pos:pos]
+					wantSkipped := expectedTestValue(dialect, test.skipped)
+					if skipped != wantSkipped {
+						t.Errorf("skipped mismatch\nGot:  %v\nWant: %v", skipped, wantSkipped)
+					}
+				}
+			})
+		}
+	}
+}
+
+func expectedTestValue[V any](dialect databasepb.DatabaseDialect, values map[databasepb.DatabaseDialect]V) V {
+	if values == nil {
+		var zero V
+		return zero
+	}
+	if v, ok := values[dialect]; ok {
+		return v
+	} else if v, ok := values[databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED]; ok {
+		return v
+	} else {
+		var zero V
+		return zero
 	}
 }
 
@@ -1232,8 +2062,12 @@ func TestSkipStatementHint(t *testing.T) {
 			want:  "\nselect * from foo",
 		},
 	}
+	statementParser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range tests {
-		p := &simpleParser{sql: []byte(test.input)}
+		p := &simpleParser{sql: []byte(test.input), statementParser: statementParser}
 		p.skipStatementHint()
 		if g, w := test.input[p.pos:], test.want; g != w {
 			t.Errorf("unexpected query string after statement hint %q\n Got: %v\nWant: %v", test.input, g, w)
@@ -1296,11 +2130,157 @@ func TestReadKeyword(t *testing.T) {
 			want:  "Select",
 		},
 	}
+	statementParser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range tests {
-		p := simpleParser{sql: []byte(test.input)}
+		p := simpleParser{sql: []byte(test.input), statementParser: statementParser}
 		if g, w := p.readKeyword(), test.want; g != w {
 			t.Errorf("keyword mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
 		}
+	}
+}
+
+func TestEatDollarTag(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			input: "$$",
+			want:  "",
+		},
+		{
+			input: "$tag$",
+			want:  "tag",
+		},
+		{
+			input: "$tag_with_underscore$",
+			want:  "tag_with_underscore",
+		},
+		{
+			input: "$tag1$",
+			want:  "tag1",
+		},
+		{
+			input: "$ø$",
+			want:  "ø",
+		},
+		{
+			input: "$_test$",
+			want:  "_test",
+		},
+		{
+			// A digit is not allowed as the first character of an identifier.
+			input:   "$1test$",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			// The euro sign is not a letter, and therefore not a valid char in an identifier.
+			input:   "$euro€$",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	statementParser, err := newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			p := simpleParser{sql: []byte(test.input), statementParser: statementParser}
+			tag, ok := p.eatDollarTag()
+			if !ok && !test.wantErr {
+				t.Errorf("eatDollarTag returned false")
+			} else if g, w := tag, test.want; g != w {
+				t.Errorf("tag mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
+			}
+		})
+	}
+}
+
+func TestEatDollarQuotedString(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			input: "$$test$$",
+			want:  "test",
+		},
+		{
+			input: "$tag$test$tag$",
+			want:  "test",
+		},
+		{
+			input: "$tag_with_underscore$test$tag_with_underscore$",
+			want:  "test",
+		},
+		{
+			input: "$tag1$test$tag1$",
+			want:  "test",
+		},
+		{
+			input: "$ø$test$ø$",
+			want:  "test",
+		},
+		{
+			input: "$_test$test$_test$",
+			want:  "test",
+		},
+		{
+			// A digit is not allowed as the first character of an identifier.
+			input:   "$1test$test$1test$",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			// The euro sign is not a letter, and therefore not a valid char in an identifier.
+			input:   "$euro€$test$euro€$",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			input: "$outer$ outer string $inner$ inner string $inner$ second part of outer string $outer$",
+			want:  " outer string $inner$ inner string $inner$ second part of outer string ",
+		},
+		{
+			input:   "$tag$ mismatched start and end tag $gat$",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			input:   "$outer$ outer string $inner$ mismatched tag $outer$ second part of outer string $inner$",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	statementParser, err := newStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			p := simpleParser{sql: []byte(test.input), statementParser: statementParser}
+			tag, ok := p.eatDollarTag()
+			if !ok {
+				if !test.wantErr {
+					t.Errorf("eatDollarTag returned false")
+				}
+			} else {
+				if value, ok := p.eatDollarQuotedString(tag); ok {
+					if g, w := value, test.want; g != w {
+						t.Errorf("tag mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
+					}
+				} else if !test.wantErr {
+					t.Errorf("eatDollarQuotedString returned false")
+				}
+			}
+		})
 	}
 }
 
@@ -1359,23 +2339,73 @@ func generateDetectStatementTypeTests() []detectStatementTypeTest {
 			input: "input from borkisland",
 			want:  statementTypeUnknown,
 		},
+		{
+			input: "start batch ddl",
+			want:  statementTypeClientSide,
+		},
+		{
+			input: "set autocommit_dml_mode = 'partitioned_non_atomic'",
+			want:  statementTypeClientSide,
+		},
+		{
+			input: "show variable commit_timestamp",
+			want:  statementTypeClientSide,
+		},
+		{
+			input: "run batch",
+			want:  statementTypeClientSide,
+		},
 	}
 }
 
 func TestDetectStatementType(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &conn{parser: parser}
 	tests := generateDetectStatementTypeTests()
 	for _, test := range tests {
-		if g, w := detectStatementType(test.input).statementType, test.want; g != w {
+		if cs, err := parser.parseClientSideStatement(c, test.input); err != nil {
+			t.Errorf("failed to parse the statement as a client-side statement")
+		} else if cs != nil {
+			if g, w := statementTypeClientSide, test.want; g != w {
+				t.Errorf("statement type mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
+			}
+		} else if g, w := parser.detectStatementType(test.input).statementType, test.want; g != w {
 			t.Errorf("statement type mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
 		}
 	}
 }
 
-func BenchmarkDetectStatementType(b *testing.B) {
+func BenchmarkDetectStatementTypeWithoutCache(b *testing.B) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDetectStatementType(b, parser)
+}
+
+func BenchmarkDetectStatementTypeWithCache(b *testing.B) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDetectStatementType(b, parser)
+}
+
+func benchmarkDetectStatementType(b *testing.B, parser *statementParser) {
+	c := &conn{parser: parser}
 	tests := generateDetectStatementTypeTests()
 	for b.Loop() {
 		for _, test := range tests {
-			if g, w := detectStatementType(test.input).statementType, test.want; g != w {
+			if cs, err := parser.parseClientSideStatement(c, test.input); err != nil {
+				b.Errorf("failed to parse the statement as a client-side statement")
+			} else if cs != nil {
+				if g, w := statementTypeClientSide, test.want; g != w {
+					b.Errorf("statement type mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
+				}
+			} else if g, w := parser.detectStatementType(test.input).statementType, test.want; g != w {
 				b.Errorf("statement type mismatch for %q\n Got: %v\nWant: %v", test.input, g, w)
 			}
 		}
@@ -1385,13 +2415,16 @@ func BenchmarkDetectStatementType(b *testing.B) {
 var fuzzQuerySamples = []string{"", "SELECT 1;", "RUN BATCH", "ABORT BATCH", "Show variable Retry_Aborts_Internally", "@{JOIN_METHOD=HASH_JOIN SELECT * FROM PersonsTable"}
 
 func init() {
-	for ddl := range ddlStatements {
-		fuzzQuerySamples = append(fuzzQuerySamples, ddl)
+	for statement := range ddlStatements {
+		fuzzQuerySamples = append(fuzzQuerySamples, statement)
+		fuzzQuerySamples = append(fuzzQuerySamples, statement+" foo")
 	}
-	for ddl := range selectStatements {
-		fuzzQuerySamples = append(fuzzQuerySamples, ddl)
+	for statement := range selectStatements {
+		fuzzQuerySamples = append(fuzzQuerySamples, statement)
+		fuzzQuerySamples = append(fuzzQuerySamples, statement+" foo")
 	}
-	for ddl := range dmlStatements {
-		fuzzQuerySamples = append(fuzzQuerySamples, ddl)
+	for statement := range dmlStatements {
+		fuzzQuerySamples = append(fuzzQuerySamples, statement)
+		fuzzQuerySamples = append(fuzzQuerySamples, statement+" foo")
 	}
 }

--- a/statement_parser_test.go
+++ b/statement_parser_test.go
@@ -1016,11 +1016,11 @@ func TestRemoveCommentsAndTrim_Errors(t *testing.T) {
 }
 
 func TestFindParams_Errors(t *testing.T) {
-	_, _, err := findParams('?', "SELECT 'Hello World FROM SomeTable WHERE id=@id")
+	_, _, err := findParams("SELECT 'Hello World FROM SomeTable WHERE id=@id")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}
-	_, _, err = findParams('?', "SELECT 'Hello World\nFROM SomeTable WHERE id=@id")
+	_, _, err = findParams("SELECT 'Hello World\nFROM SomeTable WHERE id=@id")
 	if g, w := spanner.ErrCode(err), codes.InvalidArgument; g != w {
 		t.Errorf("error code mismatch\nGot: %v\nWant: %v\n", g, w)
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -72,8 +72,8 @@ func (s *stmt) CheckNamedValue(value *driver.NamedValue) error {
 	return s.conn.CheckNamedValue(value)
 }
 
-func prepareSpannerStmt(q string, args []driver.NamedValue) (spanner.Statement, error) {
-	q, names, err := parseParameters(q)
+func prepareSpannerStmt(parser *statementParser, q string, args []driver.NamedValue) (spanner.Statement, error) {
+	q, names, err := parser.parseParameters(q)
 	if err != nil {
 		return spanner.Statement{}, err
 	}


### PR DESCRIPTION
The functions for determining the type of statement and which query parameters are in a statement are deterministic and do not change over time. These can therefore safely be cached. This improves the execution speed of frequently executed SQL strings, as the same parsing does not need to happen for each execution.