### PR TITLE
chore: create statementParser struct and make it dialect-aware

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -533,7 +534,12 @@ func TestConn_StartBatchDml(t *testing.T) {
 }
 
 func TestConn_NonDdlStatementsInDdlBatch(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser:            parser,
 		logger:            noopLogger,
 		autocommitDMLMode: Transactional,
 		batch:             &batch{tp: ddl},
@@ -568,7 +574,12 @@ func TestConn_NonDdlStatementsInDdlBatch(t *testing.T) {
 }
 
 func TestConn_NonDmlStatementsInDmlBatch(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser: parser,
 		logger: noopLogger,
 		batch:  &batch{tp: dml},
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
@@ -605,8 +616,12 @@ func TestConn_NonDmlStatementsInDmlBatch(t *testing.T) {
 func TestConn_GetBatchedStatements(t *testing.T) {
 	t.Parallel()
 
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
-	c := &conn{logger: noopLogger}
+	c := &conn{logger: noopLogger, parser: parser}
 	if !reflect.DeepEqual(c.GetBatchedStatements(), []spanner.Statement{}) {
 		t.Fatal("conn should return an empty slice when no batch is active")
 	}
@@ -649,8 +664,13 @@ func TestConn_GetBatchedStatements(t *testing.T) {
 }
 
 func TestConn_GetCommitTimestampAfterAutocommitDml(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := time.Now()
 	c := &conn{
+		parser:            parser,
 		logger:            noopLogger,
 		autocommitDMLMode: Transactional,
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
@@ -677,7 +697,12 @@ func TestConn_GetCommitTimestampAfterAutocommitDml(t *testing.T) {
 }
 
 func TestConn_GetCommitTimestampAfterAutocommitQuery(t *testing.T) {
+	parser, err := newStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c := &conn{
+		parser: parser,
 		logger: noopLogger,
 		execSingleQuery: func(ctx context.Context, c *spanner.Client, statement spanner.Statement, tb spanner.TimestampBound, options ExecOptions) *spanner.RowIterator {
 			return &spanner.RowIterator{}
@@ -693,7 +718,7 @@ func TestConn_GetCommitTimestampAfterAutocommitQuery(t *testing.T) {
 	if _, err := c.QueryContext(ctx, "SELECT * FROM Foo", []driver.NamedValue{}); err != nil {
 		t.Fatalf("failed to execute query: %v", err)
 	}
-	_, err := c.CommitTimestamp()
+	_, err = c.CommitTimestamp()
 	if g, w := spanner.ErrCode(err), codes.FailedPrecondition; g != w {
 		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -72,8 +72,8 @@ func (s *stmt) CheckNamedValue(value *driver.NamedValue) error {
 	return s.conn.CheckNamedValue(value)
 }
 
-func prepareSpannerStmt(q string, args []driver.NamedValue) (spanner.Statement, error) {
-	q, names, err := parseParameters(q)
+func prepareSpannerStmt(parser *statementParser, q string, args []driver.NamedValue) (spanner.Statement, error) {
+	q, names, err := parser.parseParameters(q)
 	if err != nil {
 		return spanner.Statement{}, err
 	}


### PR DESCRIPTION
Refactors the statement parser into a struct that contains a field for the database dialect that is being used. This dialect field will be used in follow-up pull request to implement dialect-specific parsing.