### PR TITLE
feat: detect database dialect and support PostgreSQL databases

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -734,7 +734,7 @@ func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, err
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	// Execute client side statement if it is one.
-	clientStmt, err := parseClientSideStatement(c, query)
+	clientStmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +794,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	// Execute client side statement if it is one.
-	stmt, err := parseClientSideStatement(c, query)
+	stmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}

--- a/driver.go
+++ b/driver.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"os"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -48,6 +49,10 @@ const userAgent = "go-sql-spanner/1.13.2" // x-release-please-version
 
 const gormModule = "github.com/googleapis/go-gorm-spanner"
 const gormUserAgent = "go-gorm-spanner"
+
+const DefaultStatementCacheSize = 1000
+
+var defaultStatementCacheSize int
 
 // LevelNotice is the default logging level that the Spanner database/sql driver
 // uses for informational logs. This level is deliberately chosen to be one level
@@ -92,6 +97,19 @@ var spannerDriver *Driver
 func init() {
 	spannerDriver = &Driver{connectors: make(map[string]*connector)}
 	sql.Register("spanner", spannerDriver)
+	determineDefaultStatementCacheSize()
+}
+
+func determineDefaultStatementCacheSize() {
+	if defaultCacheSizeString, ok := os.LookupEnv("SPANNER_DEFAULT_STATEMENT_CACHE_SIZE"); ok {
+		if defaultCacheSize, err := strconv.Atoi(defaultCacheSizeString); err == nil {
+			defaultStatementCacheSize = defaultCacheSize
+		} else {
+			defaultStatementCacheSize = DefaultStatementCacheSize
+		}
+	} else {
+		defaultStatementCacheSize = DefaultStatementCacheSize
+	}
 }
 
 // ExecOptions can be passed in as an argument to the Query, QueryContext,
@@ -210,6 +228,16 @@ type ConnectorConfig struct {
 	Project  string
 	Instance string
 	Database string
+
+	// StatementCacheSize is the size of the internal cache that is used for
+	// connectors that are created from this ConnectorConfig. This cache stores
+	// the result of parsing SQL statements for query parameters and the type of
+	// statement (Query / DML / DDL).
+	// The default size is 1000. This default can also be overridden by setting
+	// the environment variable SPANNER_DEFAULT_STATEMENT_CACHE_SIZE.
+	StatementCacheSize int
+	// DisableStatementCache disables the use of a statement cache.
+	DisableStatementCache bool
 
 	// AutoConfigEmulator automatically creates a connection for the emulator
 	// and also automatically creates the Instance and Database on the emulator.
@@ -336,6 +364,7 @@ type connector struct {
 	adminClient    *adminapi.DatabaseAdminClient
 	adminClientErr error
 	connCount      int32
+	parser         *statementParser
 }
 
 func newOrCachedConnector(d *Driver, dsn string) (*connector, error) {
@@ -481,6 +510,11 @@ func createConnector(d *Driver, connectorConfig ConnectorConfig) (*connector, er
 			connectorConfig.IsolationLevel = val
 		}
 	}
+	if strval, ok := connectorConfig.Params[strings.ToLower("StatementCacheSize")]; ok {
+		if val, err := strconv.Atoi(strval); err == nil {
+			connectorConfig.StatementCacheSize = val
+		}
+	}
 
 	// Check if it is Spanner gorm that is creating the connection.
 	// If so, we should set a different user-agent header than the
@@ -568,11 +602,6 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 		c.connectorConfig.Instance,
 		c.connectorConfig.Database)
 
-	// TODO: Get dialect from the database and make cache size configurable.
-	parser, err := getStatementParser(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, 1000)
-	if err != nil {
-		return nil, err
-	}
 	if err := c.increaseConnCount(ctx, databaseName, opts); err != nil {
 		return nil, err
 	}
@@ -580,7 +609,7 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 	connId := uuid.New().String()
 	logger := c.logger.With("connId", connId)
 	connection := &conn{
-		parser:      parser,
+		parser:      c.parser,
 		connector:   c,
 		client:      c.client,
 		adminClient: c.adminClient,
@@ -621,12 +650,33 @@ func (c *connector) increaseConnCount(ctx context.Context, databaseName string, 
 		if c.clientErr != nil {
 			return c.clientErr
 		}
+		c.logger.Log(ctx, LevelNotice, "fetching database dialect")
+		closeClient := func() {
+			c.client.Close()
+			c.client = nil
+		}
+		if dialect, err := determineDialect(ctx, c.client); err != nil {
+			closeClient()
+			return err
+		} else {
+			// Create a separate statement parser and cache per connector.
+			cacheSize := c.connectorConfig.StatementCacheSize
+			if c.connectorConfig.DisableStatementCache {
+				cacheSize = 0
+			} else if c.connectorConfig.StatementCacheSize == 0 {
+				cacheSize = defaultStatementCacheSize
+			}
+			c.parser, err = newStatementParser(dialect, cacheSize)
+			if err != nil {
+				closeClient()
+				return err
+			}
+		}
 
 		c.logger.Log(ctx, LevelNotice, "creating Spanner Admin client")
 		c.adminClient, c.adminClientErr = adminapi.NewDatabaseAdminClient(ctx, opts...)
 		if c.adminClientErr != nil {
-			c.client = nil
-			c.client.Close()
+			closeClient()
 			c.adminClient = nil
 			return c.adminClientErr
 		}
@@ -635,6 +685,26 @@ func (c *connector) increaseConnCount(ctx context.Context, databaseName string, 
 	c.connCount++
 	c.logger.DebugContext(ctx, "increased conn count", "connCount", c.connCount)
 	return nil
+}
+
+func determineDialect(ctx context.Context, client *spanner.Client) (databasepb.DatabaseDialect, error) {
+	it := client.Single().Query(ctx, spanner.Statement{SQL: "select option_value from information_schema.database_options where option_name='database_dialect'"})
+	defer it.Stop()
+	for {
+		if row, err := it.Next(); err != nil {
+			return databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, err
+		} else {
+			var dialectName string
+			if err := row.Columns(&dialectName); err != nil {
+				return databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, err
+			}
+			if dialect, ok := databasepb.DatabaseDialect_value[dialectName]; ok {
+				return databasepb.DatabaseDialect(dialect), nil
+			} else {
+				return databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED, fmt.Errorf("unknown database dialect: %s", dialectName)
+			}
+		}
+	}
 }
 
 // decreaseConnCount decreases the number of connections that are active and closes the underlying clients if it was the

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -3604,6 +3604,9 @@ func TestTag_RunTransaction_Retry(t *testing.T) {
 
 	conn, err := db.Conn(ctx)
 	defer func() {
+		if conn == nil {
+			return
+		}
 		if err := conn.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -4477,6 +4480,73 @@ func TestCustomClientConfig(t *testing.T) {
 	}
 }
 
+func TestPostgreSQLDialect(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnectionWithDialect(t, databasepb.DatabaseDialect_POSTGRESQL)
+	defer teardown()
+	_ = server.TestSpanner.PutStatementResult(
+		"SELECT * FROM Test WHERE Id=$1",
+		&testutil.StatementResult{
+			Type:      testutil.StatementResultResultSet,
+			ResultSet: testutil.CreateSelect1ResultSet(),
+		},
+	)
+
+	// The positional query parameter should be replaced with a PostgreSQL-style parameter.
+	stmt, err := db.Prepare("SELECT * FROM Test WHERE Id=?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for want := int64(1); rows.Next(); want++ {
+		var got int64
+		err = rows.Scan(&got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("value mismatch\n Got: %v\nWant: %v", got, want)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+	requests := drainRequestsFromServer(server.TestSpanner)
+	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	if g, w := len(sqlRequests), 1; g != w {
+		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	req := sqlRequests[0].(*sppb.ExecuteSqlRequest)
+	if g, w := len(req.ParamTypes), 1; g != w {
+		t.Fatalf("param types length mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if pt, ok := req.ParamTypes["p1"]; ok {
+		if g, w := pt.Code, sppb.TypeCode_INT64; g != w {
+			t.Fatalf("param type mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	} else {
+		t.Fatalf("no param type found for $1")
+	}
+	if g, w := len(req.Params.Fields), 1; g != w {
+		t.Fatalf("params length mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if val, ok := req.Params.Fields["p1"]; ok {
+		if g, w := val.GetStringValue(), "1"; g != w {
+			t.Fatalf("param value mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	} else {
+		t.Fatalf("no value found for param $1")
+	}
+}
+
 func numeric(v string) big.Rat {
 	res, _ := big.NewRat(1, 1).SetString(v)
 	return *res
@@ -4514,8 +4584,16 @@ func setupTestDBConnection(t *testing.T) (db *sql.DB, server *testutil.MockedSpa
 	return setupTestDBConnectionWithParams(t, "")
 }
 
+func setupTestDBConnectionWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+	return setupTestDBConnectionWithParamsAndDialect(t, "", dialect)
+}
+
 func setupTestDBConnectionWithParams(t *testing.T, params string) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
-	server, _, serverTeardown := setupMockedTestServer(t)
+	return setupTestDBConnectionWithParamsAndDialect(t, params, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+}
+
+func setupTestDBConnectionWithParamsAndDialect(t *testing.T, params string, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+	server, _, serverTeardown := setupMockedTestServerWithDialect(t, dialect)
 	db, err := sql.Open(
 		"spanner",
 		fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true;%s", server.Address, params))
@@ -4573,12 +4651,22 @@ func setupMockedTestServer(t *testing.T) (server *testutil.MockedSpannerInMemTes
 	return setupMockedTestServerWithConfig(t, spanner.ClientConfig{})
 }
 
+func setupMockedTestServerWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, spanner.ClientConfig{}, []option.ClientOption{}, dialect)
+}
+
 func setupMockedTestServerWithConfig(t *testing.T, config spanner.ClientConfig) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfigAndClientOptions(t, config, []option.ClientOption{})
 }
 
 func setupMockedTestServerWithConfigAndClientOptions(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, config, clientOptions, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+}
+
+func setupMockedTestServerWithConfigAndClientOptionsAndDialect(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	server, opts, serverTeardown := testutil.NewMockedSpannerInMemTestServer(t)
+	server.SetupSelectDialectResult(dialect)
+
 	opts = append(opts, clientOptions...)
 	ctx := context.Background()
 	formattedDatabase := fmt.Sprintf("projects/%s/instances/%s/databases/%s", "[PROJECT]", "[INSTANCE]", "[DATABASE]")

--- a/integration_test.go
+++ b/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -153,6 +154,10 @@ func initTestInstance(config string) (cleanup func(), err error) {
 }
 
 func createTestDB(ctx context.Context, statements ...string) (dsn string, cleanup func(), err error) {
+	return createTestDBWithDialect(ctx, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, statements...)
+}
+
+func createTestDBWithDialect(ctx context.Context, dialect databasepb.DatabaseDialect, statements ...string) (dsn string, cleanup func(), err error) {
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
 		return "", nil, err
@@ -169,11 +174,24 @@ func createTestDB(ctx context.Context, statements ...string) (dsn string, cleanu
 	}
 
 	databaseId := fmt.Sprintf("%s-%x", prefix, uniqueid)
-	opDB, err := databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
-		Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
-		CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", databaseId),
-		ExtraStatements: statements,
-	})
+	var opDB *database.CreateDatabaseOperation
+	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
+		if len(statements) > 0 {
+			return "", nil, errors.New("PostgreSQL does not allow extra statements in the CREATE DATABASE call")
+		}
+		opDB, err = databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+			Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
+			CreateStatement: fmt.Sprintf(`CREATE DATABASE "%s"`, databaseId),
+			DatabaseDialect: dialect,
+		})
+	} else {
+		opDB, err = databaseAdminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
+			Parent:          fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
+			CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", databaseId),
+			ExtraStatements: statements,
+			DatabaseDialect: dialect,
+		})
+	}
 	if err != nil {
 		return "", nil, err
 	} else {
@@ -2339,6 +2357,38 @@ func TestCanRetryTransaction(t *testing.T) {
 		if !withInternalRetries && !aborted {
 			t.Fatalf("missing aborted error with internal retries disabled")
 		}
+	}
+}
+
+func TestPostgreSQL(t *testing.T) {
+	skipIfShort(t)
+	t.Parallel()
+
+	// Create test database.
+	ctx := context.Background()
+	dsn, cleanup, err := createTestDBWithDialect(ctx, databasepb.DatabaseDialect_POSTGRESQL)
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer cleanup()
+	// Open db.
+	db, err := sql.Open("spanner", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx, "create table test (id bigint primary key, value varchar)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err = db.ExecContext(ctx, `INSERT INTO test (id, value) values ($1, $2)`, 1, "One"); err != nil {
+		t.Fatalf("failed to insert row: %v", err)
+	}
+
+	row := db.QueryRowContext(ctx, "select value from test where id=?", 1)
+	var val string
+	if err := row.Scan(&val); err != nil {
+		t.Fatalf("failed to scan row: %v", err)
 	}
 }
 


### PR DESCRIPTION
Automatically detect the dialect of the database that the driver connects to, and modify the way that query parameters are recognized based on the dialect of the database. This makes it possible to use this driver with Spanner databases that use the PostgreSQL dialect.