### PR TITLE
perf: cache client-side SQL parsing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -734,7 +734,7 @@ func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, err
 
 func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	// Execute client side statement if it is one.
-	clientStmt, err := parseClientSideStatement(c, query)
+	clientStmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +794,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	// Execute client side statement if it is one.
-	stmt, err := parseClientSideStatement(c, query)
+	stmt, err := c.parser.parseClientSideStatement(c, query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cache the outcome of parsing a potential client-side SQL statement to prevent the same regular expressions to be tested repeatedly. Also, the initial check whether a statement is a client-side statement has been replaced with a keyword based check: Instead of trying to match the SQL statement against the list of all possible client-side statements, the parser first checks whether the first keyword is a keyword that could potentially be a client-side statement. If it is not, then the function returns early.

Benchmarks:

```
BenchmarkDetectStatementTypeWithCache-8      12530068     942 ns/op
BenchmarkDetectStatementTypeWithoutCache-8    2861143    4182 ns/op
```