### PR TITLE
fix: return explicit error message when using DDL statements with QueryContext

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -773,6 +773,8 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 			return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "PartitionQuery is only supported in batch read-only transactions"))
 		} else if execOptions.PartitionedQueryOptions.AutoPartitionQuery {
 			return c.executeAutoPartitionedQuery(ctx, query, args)
+		} else if statementType.statementType == statementTypeDdl {
+			return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "failed to perform DDL operation. Use ExecContext method to execute DDL statements"))
 		} else {
 			// The statement was either detected as being a query, or potentially not recognized at all.
 			// In that case, just default to using a single-use read-only transaction and let Spanner

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -239,3 +239,20 @@ func TestIsolationLevelAutoCommit(t *testing.T) {
 		}
 	}
 }
+
+func TestDDLUsingQueryContext(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+
+	// DDL statements should not use the query context.
+	_, err := db.QueryContext(ctx, "CREATE TABLE Foo (Bar STRING(100))")
+	if err == nil {
+		t.Fatal("expected error for DDL statement using QueryContext, got nil")
+	}
+	if g, w := err.Error(), `spanner: code = "FailedPrecondition", desc = "failed to perform DDL operation. Use ExecContext method to execute DDL statements"`; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -252,7 +252,52 @@ func TestDDLUsingQueryContext(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for DDL statement using QueryContext, got nil")
 	}
-	if g, w := err.Error(), `spanner: code = "FailedPrecondition", desc = "failed to perform DDL operation. Use ExecContext method to execute DDL statements"`; g != w {
+	if g, w := err.Error(), `spanner: code = "FailedPrecondition", desc = "QueryContext does not support DDL statements, use ExecContext instead"`; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestDDLUsingQueryContextInReadOnlyTx(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	// DDL statements should not use the query context in a read-only transaction.
+	_, err = tx.QueryContext(ctx, "CREATE TABLE Foo (Bar STRING(100))")
+	if err == nil {
+		t.Fatal("expected error for DDL statement using QueryContext in read-only transaction, got nil")
+	}
+	if g, w := err.Error(), `spanner: code = "FailedPrecondition", desc = "QueryContext does not support DDL statements, use ExecContext instead"`; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestDDLUsingQueryContextInReadWriteTransaction(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnection(t)
+	defer teardown()
+	ctx := context.Background()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+
+	// DDL statements should not use the query context in a read-write transaction.
+	_, err = tx.QueryContext(ctx, "CREATE TABLE Foo (Bar STRING(100))")
+	if err == nil {
+		t.Fatal("expected error for DDL statement using QueryContext in read-write transaction, got nil")
+	}
+	if g, w := err.Error(), `spanner: code = "FailedPrecondition", desc = "QueryContext does not support DDL statements, use ExecContext instead"`; g != w {
 		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/go-sql-spanner/issues/437