### PR TITLE
fix: wrap AlreadyExists error for instance creation when autoConfigEmulator=true

### DIFF
--- a/emulator_util.go
+++ b/emulator_util.go
@@ -64,7 +64,7 @@ func createInstance(projectId, instanceId string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not create instance %s: %v", fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId), err)
+		return fmt.Errorf("could not create instance %s: %w", fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId), err)
 	}
 	// Wait for the instance creation to finish.
 	if _, err := op.Wait(ctx); err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -270,6 +270,34 @@ func skipIfEmulator(t *testing.T, msg string) {
 	}
 }
 
+func TestAutoConfigEmulator(t *testing.T) {
+	skipIfShort(t)
+	if !runsOnEmulator() {
+		t.Skip("autoConfigEmulator=true only works when connected to the emulator")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	for range 2 {
+		db, err := sql.Open("spanner", "projects/emulator-project/instances/test-instance/databases/test-database;autoConfigEmulator=true")
+		if err != nil {
+			t.Fatalf("could not connect to emulator: %v", err)
+		}
+		row := db.QueryRowContext(ctx, "select 1")
+		if row.Err() != nil {
+			t.Fatalf("could not execute select 1: %v", row.Err())
+		}
+		var v int64
+		if err := row.Scan(&v); err != nil {
+			t.Fatalf("could not scan value from select 1: %v", err)
+		}
+		if g, w := v, int64(1); g != w {
+			t.Fatalf("value mismatch:\n Got %d\nWant %d", g, w)
+		}
+		_ = db.Close()
+	}
+}
+
 func TestQueryContext(t *testing.T) {
 	skipIfShort(t)
 	t.Parallel()


### PR DESCRIPTION
Wrap the AlreadyExists error when instance creation fails with autoConfigEmulator=true.
This ensures that the error is correctly recognized, and that the error is not propagated
to the application.

Credits to @DanielvNiek for spotting and fixing this in the first place.

Replaces #449
Fixes #448