### PR TITLE
feat: add DirectExecuteQuery option

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"log/slog"
 	"slices"
 	"time"
@@ -793,7 +794,16 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 			return nil, err
 		}
 	}
-	return &rows{it: iter, decodeOption: execOptions.DecodeOption, decodeToNativeArrays: execOptions.DecodeToNativeArrays}, nil
+	res := &rows{it: iter, decodeOption: execOptions.DecodeOption, decodeToNativeArrays: execOptions.DecodeToNativeArrays}
+	if execOptions.DirectExecuteQuery {
+		// This call to res.getColumns() triggers the execution of the statement, as it needs to fetch the metadata.
+		res.getColumns()
+		if res.dirtyErr != nil && !errors.Is(res.dirtyErr, iterator.Done) {
+			_ = res.Close()
+			return nil, res.dirtyErr
+		}
+	}
+	return res, nil
 }
 
 func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {

--- a/driver.go
+++ b/driver.go
@@ -163,6 +163,13 @@ type ExecOptions struct {
 	// AutoCommitDMLMode determines the type of transaction that DML statements
 	// that are executed outside explicit transactions use.
 	AutocommitDMLMode AutocommitDMLMode
+
+	// DirectExecute determines whether a query is executed directly when the
+	// [sql.DB.QueryContext] method is called, or whether the actual query execution
+	// is delayed until the first call to [sql.Rows.Next]. The default is to delay
+	// the execution. Set this flag to true to execute the query directly when
+	// [sql.DB.QueryContext] is called.
+	DirectExecuteQuery bool
 }
 
 type DecodeOption int


### PR DESCRIPTION
Adds an option to directly execute the query when QueryContext is called. Without this option, the query execution is delayed until the first call to Rows.Next. This again also delays any query errors until the first call to Rows.Next, which can be confusing in some cases.