### PR TITLE
fix(emulator_util): remove `os.Setenv` call

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -261,10 +261,8 @@ type ConnectorConfig struct {
 	// AutoConfigEmulator automatically creates a connection for the emulator
 	// and also automatically creates the Instance and Database on the emulator.
 	// Setting this option to true will:
-	// 1. Set the SPANNER_EMULATOR_HOST environment variable to either Host or
-	//    'localhost:9010' if no other host has been set.
-	// 2. Use plain text communication and NoCredentials.
-	// 3. Automatically create the Instance and the Database on the emulator if
+	// 1. Use plain text communication and NoCredentials.
+	// 2. Automatically create the Instance and the Database on the emulator if
 	//    any of those do not yet exist.
 	AutoConfigEmulator bool
 

--- a/emulator_util.go
+++ b/emulator_util.go
@@ -17,7 +17,6 @@ package spannerdriver
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -28,12 +27,6 @@ import (
 )
 
 func autoConfigEmulator(ctx context.Context, host, project, instance, database string) error {
-	if host == "" {
-		host = "localhost:9010"
-	}
-	if err := os.Setenv("SPANNER_EMULATOR_HOST", host); err != nil {
-		return err
-	}
 	if err := createInstance(project, instance); err != nil {
 		if spanner.ErrCode(err) != codes.AlreadyExists {
 			return err


### PR DESCRIPTION
see: https://github.com/googleapis/go-sql-spanner/issues/459