### PR TITLE
fix: include mutations from original attempt in retry

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -221,6 +221,10 @@ type readWriteTransaction struct {
 	// transaction so far. These statements will be replayed on a new read write
 	// transaction if the initial attempt is aborted.
 	statements []retriableStatement
+
+	// mutations contains the buffered mutations of this transaction. These are
+	// added to the next transaction if the transaction executes an internal retry.
+	mutations []*spanner.Mutation
 }
 
 // retriableStatement is the interface that is used to keep track of statements
@@ -350,6 +354,10 @@ func (tx *readWriteTransaction) retry(ctx context.Context) (err error) {
 	tx.rwTx, err = tx.rwTx.ResetForRetry(ctx)
 	if err != nil {
 		tx.logger.Log(ctx, LevelNotice, "failed to reset transaction")
+		return err
+	}
+	// Re-apply the mutations from the previous transaction.
+	if err := tx.rwTx.BufferWrite(tx.mutations); err != nil {
 		return err
 	}
 	for _, stmt := range tx.statements {
@@ -588,6 +596,7 @@ func (tx *readWriteTransaction) runDmlBatch(ctx context.Context) (*result, error
 }
 
 func (tx *readWriteTransaction) BufferWrite(ms []*spanner.Mutation) error {
+	tx.mutations = append(tx.mutations, ms...)
 	return tx.rwTx.BufferWrite(ms)
 }
 


### PR DESCRIPTION
Mutations that had been buffered during a transaction would not be included in internal retries if the original transaction was aborted.