### PR TITLE
perf: inline BeginTransaction with first statement

### DIFF
--- a/aborted_transactions_test.go
+++ b/aborted_transactions_test.go
@@ -325,7 +325,7 @@ func TestQueryWithError_CommitAborted(t *testing.T) {
 		server.PutExecutionTime(testutil.MethodCommitTransaction, testutil.SimulatedExecutionTime{
 			Errors: []error{status.Error(codes.Aborted, "Aborted")},
 		})
-	}, codes.NotFound, 0, 2, 2)
+	}, codes.NotFound, 0, 3, 2)
 }
 
 func TestQueryWithErrorHalfway_CommitAborted(t *testing.T) {
@@ -1080,7 +1080,7 @@ func TestBatchUpdateAbortedWithError_DifferentErrorDuringRetry(t *testing.T) {
 		t.Fatalf("dml statement failed: %v", err)
 	}
 	if _, err := tx.ExecContext(ctx, "RUN BATCH"); spanner.ErrCode(err) != codes.NotFound {
-		t.Fatalf("error code mismatch\nGot: %v\nWant: %v", spanner.ErrCode(err), codes.NotFound)
+		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", spanner.ErrCode(err), codes.NotFound)
 	}
 
 	// Remove the error for the DML statement and cause a retry. The missing
@@ -1094,19 +1094,37 @@ func TestBatchUpdateAbortedWithError_DifferentErrorDuringRetry(t *testing.T) {
 	})
 	err = tx.Commit()
 	if err != ErrAbortedDueToConcurrentModification {
-		t.Fatalf("commit error mismatch\nGot: %v\nWant: %v", err, ErrAbortedDueToConcurrentModification)
+		t.Fatalf("commit error mismatch\n Got: %v\nWant: %v", err, ErrAbortedDueToConcurrentModification)
 	}
 	reqs := drainRequestsFromServer(server.TestSpanner)
 	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
-	if g, w := len(execReqs), 2; g != w {
-		t.Fatalf("batch request count mismatch\nGot: %v\nWant: %v", g, w)
+	// There are 3 ExecuteBatchDmlRequests sent to Spanner:
+	// 1. An initial attempt with a BeginTransaction RPC, but this returns a NotFound error.
+	//    This causes the transaction to be retried with an explicit BeginTransaction request.
+	// 2. Another attempt with a transaction ID.
+	// 3. A third attempt after the initial transaction is aborted.
+	if g, w := len(execReqs), 3; g != w {
+		t.Fatalf("batch request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
 	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	// The commit should be attempted only once.
 	if g, w := len(commitReqs), 1; g != w {
-		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
+		t.Fatalf("commit request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-
+	// The first ExecuteBatchDml request should try to use an inline-begin.
+	// After that, we should have two BeginTransaction requests.
+	req1 := execReqs[0].(*sppb.ExecuteBatchDmlRequest)
+	if req1.GetTransaction() == nil || req1.GetTransaction().GetBegin() == nil {
+		t.Fatal("the first ExecuteBatchDmlRequest should have a BeginTransaction")
+	}
+	req2 := execReqs[1].(*sppb.ExecuteBatchDmlRequest)
+	if req2.GetTransaction() == nil || req2.GetTransaction().GetId() == nil {
+		t.Fatal("the second ExecuteBatchDmlRequest should have a transaction id")
+	}
+	beginRequests := requestsOfType(reqs, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 2; g != w {
+		t.Fatalf("begin request count mismatch\n Got: %v\nWant: %v", g, w)
+	}
 	// Verify that the db is still usable.
 	if _, err := db.ExecContext(ctx, testutil.UpdateSingersSetLastName); err != nil {
 		t.Fatalf("failed to execute statement after transaction: %v", err)

--- a/auto_dml_batch_test.go
+++ b/auto_dml_batch_test.go
@@ -303,8 +303,13 @@ func TestAutoBatchDml_FollowedByRollback(t *testing.T) {
 		if g, w := len(commitRequests), 0; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
+		beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+		if g, w := len(beginRequests), 0; g != w {
+			t.Fatalf("num BeginTransaction requests mismatch\n Got: %v\nWant: %v", g, w)
+		}
 		rollbackRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
-		if g, w := len(rollbackRequests), 1; g != w {
+		// There are no rollback requests sent to Spanner, as the transaction is never started.
+		if g, w := len(rollbackRequests), 0; g != w {
 			t.Fatalf("num rollback requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
 	}

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -39,11 +39,18 @@ func TestBeginTx(t *testing.T) {
 
 	requests := drainRequestsFromServer(server.TestSpanner)
 	beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
-	if g, w := len(beginRequests), 1; g != w {
+	if g, w := len(beginRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	request := beginRequests[0].(*spannerpb.BeginTransactionRequest)
-	if g, w := request.Options.GetIsolationLevel(), spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED; g != w {
+	executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+	if g, w := len(executeRequests), 1; g != w {
+		t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	request := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+	if request.GetTransaction() == nil || request.GetTransaction().GetBegin() == nil {
+		t.Fatal("missing begin transaction on ExecuteSqlRequest")
+	}
+	if g, w := request.GetTransaction().GetBegin().GetIsolationLevel(), spannerpb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED; g != w {
 		t.Fatalf("begin isolation level mismatch\n Got: %v\nWant: %v", g, w)
 	}
 }
@@ -76,12 +83,19 @@ func TestBeginTxWithIsolationLevel(t *testing.T) {
 
 			requests := drainRequestsFromServer(server.TestSpanner)
 			beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
-			if g, w := len(beginRequests), 1; g != w {
+			if g, w := len(beginRequests), 0; g != w {
 				t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
 			}
-			request := beginRequests[0].(*spannerpb.BeginTransactionRequest)
+			executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+			if g, w := len(executeRequests), 1; g != w {
+				t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
+			}
+			request := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+			if request.GetTransaction() == nil || request.GetTransaction().GetBegin() == nil {
+				t.Fatalf("execute request does not have a begin transaction")
+			}
 			wantIsolationLevel, _ := toProtoIsolationLevel(originalLevel)
-			if g, w := request.Options.GetIsolationLevel(), wantIsolationLevel; g != w {
+			if g, w := request.GetTransaction().GetBegin().GetIsolationLevel(), wantIsolationLevel; g != w {
 				t.Fatalf("begin isolation level mismatch\n Got: %v\nWant: %v", g, w)
 			}
 		}
@@ -162,12 +176,19 @@ func TestDefaultIsolationLevel(t *testing.T) {
 
 			requests := drainRequestsFromServer(server.TestSpanner)
 			beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
-			if g, w := len(beginRequests), 1; g != w {
+			if g, w := len(beginRequests), 0; g != w {
 				t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
 			}
-			request := beginRequests[0].(*spannerpb.BeginTransactionRequest)
+			executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+			if g, w := len(executeRequests), 1; g != w {
+				t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
+			}
+			request := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+			if request.GetTransaction() == nil || request.GetTransaction().GetBegin() == nil {
+				t.Fatalf("ExecuteSqlRequest should have a Begin transaction")
+			}
 			wantIsolationLevel, _ := toProtoIsolationLevel(originalLevel)
-			if g, w := request.Options.GetIsolationLevel(), wantIsolationLevel; g != w {
+			if g, w := request.GetTransaction().GetBegin().GetIsolationLevel(), wantIsolationLevel; g != w {
 				t.Fatalf("begin isolation level mismatch\n Got: %v\nWant: %v", g, w)
 			}
 		}

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -55,6 +55,53 @@ func TestBeginTx(t *testing.T) {
 	}
 }
 
+func TestExplicitBeginTx(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnectionWithConnectorConfig(t, ConnectorConfig{
+		Project:  "p",
+		Instance: "i",
+		Database: "d",
+
+		BeginTransactionOption: spanner.ExplicitBeginTransaction,
+	})
+	defer teardown()
+	ctx := context.Background()
+
+	for _, readOnly := range []bool{true, false} {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: readOnly})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := tx.QueryContext(ctx, testutil.SelectFooFromBar)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for res.Next() {
+		}
+		if err := res.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+
+		requests := drainRequestsFromServer(server.TestSpanner)
+		beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+		if g, w := len(beginRequests), 1; g != w {
+			t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
+		}
+		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		if g, w := len(executeRequests), 1; g != w {
+			t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
+		}
+		request := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+		if request.GetTransaction() == nil || request.GetTransaction().GetId() == nil {
+			t.Fatal("missing transaction id on ExecuteSqlRequest")
+		}
+	}
+}
+
 func TestBeginTxWithIsolationLevel(t *testing.T) {
 	t.Parallel()
 

--- a/driver.go
+++ b/driver.go
@@ -1026,7 +1026,8 @@ func clearTempReadWriteTransactionOptions(conn *sql.Conn) {
 // ReadOnlyTransactionOptions can be used to create a read-only transaction
 // on a Spanner connection.
 type ReadOnlyTransactionOptions struct {
-	TimestampBound spanner.TimestampBound
+	TimestampBound         spanner.TimestampBound
+	BeginTransactionOption spanner.BeginTransactionOption
 
 	close func()
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -171,6 +171,23 @@ func TestExtractDnsParts(t *testing.T) {
 				Params: map[string]string{
 					"isolationlevel": "repeatable_read",
 				},
+				IsolationLevel: sql.LevelRepeatableRead,
+			},
+			wantSpannerConfig: spanner.ClientConfig{
+				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
+				UserAgent:         userAgent,
+			},
+		},
+		{
+			input: "projects/p/instances/i/databases/d?beginTransactionOption=ExplicitBeginTransaction",
+			wantConnectorConfig: ConnectorConfig{
+				Project:  "p",
+				Instance: "i",
+				Database: "d",
+				Params: map[string]string{
+					"begintransactionoption": "ExplicitBeginTransaction",
+				},
+				BeginTransactionOption: spanner.ExplicitBeginTransaction,
 			},
 			wantSpannerConfig: spanner.ClientConfig{
 				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
@@ -186,6 +203,7 @@ func TestExtractDnsParts(t *testing.T) {
 				Params: map[string]string{
 					"statementcachesize": "100",
 				},
+				StatementCacheSize: 100,
 			},
 			wantSpannerConfig: spanner.ClientConfig{
 				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
@@ -252,8 +270,7 @@ func TestExtractDnsParts(t *testing.T) {
 				if tc.wantErr {
 					t.Error("did not encounter expected error")
 				}
-				tc.wantConnectorConfig.name = tc.input
-				if diff := cmp.Diff(config, tc.wantConnectorConfig, cmp.AllowUnexported(ConnectorConfig{})); diff != "" {
+				if diff := cmp.Diff(config.Params, tc.wantConnectorConfig.Params); diff != "" {
 					t.Errorf("connector config mismatch for %q\n%v", tc.input, diff)
 				}
 				conn, err := newOrCachedConnector(&Driver{connectors: make(map[string]*connector)}, tc.input)
@@ -263,6 +280,47 @@ func TestExtractDnsParts(t *testing.T) {
 				if diff := cmp.Diff(conn.spannerClientConfig, tc.wantSpannerConfig, cmpopts.IgnoreUnexported(spanner.ClientConfig{}, spanner.SessionPoolConfig{}, spanner.InactiveTransactionRemovalOptions{}, spannerpb.ExecuteSqlRequest_QueryOptions{})); diff != "" {
 					t.Errorf("connector Spanner client config mismatch for %q\n%v", tc.input, diff)
 				}
+				actualConfig := conn.connectorConfig
+				actualConfig.name = ""
+				if diff := cmp.Diff(actualConfig, tc.wantConnectorConfig, cmp.AllowUnexported(ConnectorConfig{})); diff != "" {
+					t.Errorf("actual connector config mismatch for %q\n%v", tc.input, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBeginTransactionOption(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    spanner.BeginTransactionOption
+		wantErr bool
+	}{
+		{
+			input: "DefaultBeginTransaction",
+			want:  spanner.DefaultBeginTransaction,
+		},
+		{
+			input: "InlinedBeginTransaction",
+			want:  spanner.InlinedBeginTransaction,
+		},
+		{
+			input: "ExplicitBeginTransaction",
+			want:  spanner.ExplicitBeginTransaction,
+		},
+		{
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			val, err := parseBeginTransactionOption(test.input)
+			if (err != nil) != test.wantErr {
+				t.Errorf("%d: parseBeginTransactionOption(%q) error = %v, wantErr %v", i, err, test.wantErr, err)
+			}
+			if g, w := val, test.want; g != w {
+				t.Errorf("%d: parseBeginTransactionOption(%q) = %v, want %v", i, g, w, g)
 			}
 		})
 	}


### PR DESCRIPTION
Inline the BeginTransaction option with the first statement in the transaction, instead of executing a separate BeginTransaction RPC. This reduces the number of round-trips to Spanner by one for all transactions that have at least one SQL statement.

Using line-begin improves performance for most transaction shapes, as it requires one less round-trip to Spanner. Some transaction shapes do not benefit from this. These are:
1. Transactions that only write mutations still need an explicit BeginTransaction RPC to be executed, as mutations are included in the Commit RPC. The Commit RPC can also start a transaction, but such transactions are not guaranteed to be applied only once to Spanner.
2. Transactions that execute multiple parallel queries at the start of the transaction can see higher end-to-end execution times, as only one query can include the BeginTransaction option. All other queries must wait for the first query to return at least one result, which also includes the transaction identifier, before they can proceed.

The default for the database/sql driver is to use inline-begin. A follow-up pull request will add an option to the driver to set a different default for a connection.