### PR TITLE
feat: add BeginTransactionOption

### DIFF
--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -55,6 +55,53 @@ func TestBeginTx(t *testing.T) {
 	}
 }
 
+func TestExplicitBeginTx(t *testing.T) {
+	t.Parallel()
+
+	db, server, teardown := setupTestDBConnectionWithConnectorConfig(t, ConnectorConfig{
+		Project:  "p",
+		Instance: "i",
+		Database: "d",
+
+		BeginTransactionOption: spanner.ExplicitBeginTransaction,
+	})
+	defer teardown()
+	ctx := context.Background()
+
+	for _, readOnly := range []bool{true, false} {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: readOnly})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := tx.QueryContext(ctx, testutil.SelectFooFromBar)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for res.Next() {
+		}
+		if err := res.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+
+		requests := drainRequestsFromServer(server.TestSpanner)
+		beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+		if g, w := len(beginRequests), 1; g != w {
+			t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
+		}
+		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		if g, w := len(executeRequests), 1; g != w {
+			t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
+		}
+		request := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+		if request.GetTransaction() == nil || request.GetTransaction().GetId() == nil {
+			t.Fatal("missing transaction id on ExecuteSqlRequest")
+		}
+	}
+}
+
 func TestBeginTxWithIsolationLevel(t *testing.T) {
 	t.Parallel()
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -171,6 +171,23 @@ func TestExtractDnsParts(t *testing.T) {
 				Params: map[string]string{
 					"isolationlevel": "repeatable_read",
 				},
+				IsolationLevel: sql.LevelRepeatableRead,
+			},
+			wantSpannerConfig: spanner.ClientConfig{
+				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
+				UserAgent:         userAgent,
+			},
+		},
+		{
+			input: "projects/p/instances/i/databases/d?beginTransactionOption=ExplicitBeginTransaction",
+			wantConnectorConfig: ConnectorConfig{
+				Project:  "p",
+				Instance: "i",
+				Database: "d",
+				Params: map[string]string{
+					"begintransactionoption": "ExplicitBeginTransaction",
+				},
+				BeginTransactionOption: spanner.ExplicitBeginTransaction,
 			},
 			wantSpannerConfig: spanner.ClientConfig{
 				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
@@ -186,6 +203,7 @@ func TestExtractDnsParts(t *testing.T) {
 				Params: map[string]string{
 					"statementcachesize": "100",
 				},
+				StatementCacheSize: 100,
 			},
 			wantSpannerConfig: spanner.ClientConfig{
 				SessionPoolConfig: spanner.DefaultSessionPoolConfig,
@@ -252,8 +270,7 @@ func TestExtractDnsParts(t *testing.T) {
 				if tc.wantErr {
 					t.Error("did not encounter expected error")
 				}
-				tc.wantConnectorConfig.name = tc.input
-				if diff := cmp.Diff(config, tc.wantConnectorConfig, cmp.AllowUnexported(ConnectorConfig{})); diff != "" {
+				if diff := cmp.Diff(config.Params, tc.wantConnectorConfig.Params); diff != "" {
 					t.Errorf("connector config mismatch for %q\n%v", tc.input, diff)
 				}
 				conn, err := newOrCachedConnector(&Driver{connectors: make(map[string]*connector)}, tc.input)
@@ -263,6 +280,47 @@ func TestExtractDnsParts(t *testing.T) {
 				if diff := cmp.Diff(conn.spannerClientConfig, tc.wantSpannerConfig, cmpopts.IgnoreUnexported(spanner.ClientConfig{}, spanner.SessionPoolConfig{}, spanner.InactiveTransactionRemovalOptions{}, spannerpb.ExecuteSqlRequest_QueryOptions{})); diff != "" {
 					t.Errorf("connector Spanner client config mismatch for %q\n%v", tc.input, diff)
 				}
+				actualConfig := conn.connectorConfig
+				actualConfig.name = ""
+				if diff := cmp.Diff(actualConfig, tc.wantConnectorConfig, cmp.AllowUnexported(ConnectorConfig{})); diff != "" {
+					t.Errorf("actual connector config mismatch for %q\n%v", tc.input, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBeginTransactionOption(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    spanner.BeginTransactionOption
+		wantErr bool
+	}{
+		{
+			input: "DefaultBeginTransaction",
+			want:  spanner.DefaultBeginTransaction,
+		},
+		{
+			input: "InlinedBeginTransaction",
+			want:  spanner.InlinedBeginTransaction,
+		},
+		{
+			input: "ExplicitBeginTransaction",
+			want:  spanner.ExplicitBeginTransaction,
+		},
+		{
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			val, err := parseBeginTransactionOption(test.input)
+			if (err != nil) != test.wantErr {
+				t.Errorf("%d: parseBeginTransactionOption(%q) error = %v, wantErr %v", i, err, test.wantErr, err)
+			}
+			if g, w := val, test.want; g != w {
+				t.Errorf("%d: parseBeginTransactionOption(%q) = %v, want %v", i, g, w, g)
 			}
 		})
 	}


### PR DESCRIPTION
Adds a BeginTransactionOption configuration field that can be used to determine how the database/sql driver should begin transactions. The default is to inline the BeginTransaction option with the first SQL statement of the transaction. This reduces the number of round-trips needed per transaction by one for most transaction shapes.