### PR TITLE
feat: return metadata and stats for client-side statements

### DIFF
--- a/client_side_statement.go
+++ b/client_side_statement.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,6 +25,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -48,7 +48,7 @@ import (
 type statementExecutor struct {
 }
 
-func (s *statementExecutor) ShowCommitTimestamp(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowCommitTimestamp(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	ts, err := c.CommitTimestamp()
 	var commitTs *time.Time
 	if err == nil {
@@ -58,106 +58,106 @@ func (s *statementExecutor) ShowCommitTimestamp(_ context.Context, c *conn, _ st
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowRetryAbortsInternally(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowRetryAbortsInternally(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createBooleanIterator("RetryAbortsInternally", c.RetryAbortsInternally())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowAutoBatchDml(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowAutoBatchDml(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createBooleanIterator("AutoBatchDml", c.AutoBatchDml())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowAutoBatchDmlUpdateCount(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowAutoBatchDmlUpdateCount(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createInt64Iterator("AutoBatchDmlUpdateCount", c.AutoBatchDmlUpdateCount())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, opts ExecOptions, _ string, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createBooleanIterator("AutoBatchDmlUpdateCountVerification", c.AutoBatchDmlUpdateCountVerification())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowAutocommitDmlMode(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowAutocommitDmlMode(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("AutocommitDMLMode", c.AutocommitDMLMode().String())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowReadOnlyStaleness(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowReadOnlyStaleness(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("ReadOnlyStaleness", c.ReadOnlyStaleness().String())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowExcludeTxnFromChangeStreams(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowExcludeTxnFromChangeStreams(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createBooleanIterator("ExcludeTxnFromChangeStreams", c.ExcludeTxnFromChangeStreams())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowMaxCommitDelay(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowMaxCommitDelay(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("MaxCommitDelay", c.MaxCommitDelay().String())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowTransactionTag(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowTransactionTag(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("TransactionTag", c.TransactionTag())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowStatementTag(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+func (s *statementExecutor) ShowStatementTag(_ context.Context, c *conn, _ string, opts ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("StatementTag", c.StatementTag())
 	if err != nil {
 		return nil, err
 	}
-	return &rows{it: it}, nil
+	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) StartBatchDdl(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) StartBatchDdl(_ context.Context, c *conn, _ string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return c.startBatchDDL()
 }
 
-func (s *statementExecutor) StartBatchDml(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) StartBatchDml(_ context.Context, c *conn, _ string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return c.startBatchDML( /* automatic = */ false)
 }
 
-func (s *statementExecutor) RunBatch(ctx context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) RunBatch(ctx context.Context, c *conn, _ string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return c.runBatch(ctx)
 }
 
-func (s *statementExecutor) AbortBatch(_ context.Context, c *conn, _ string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) AbortBatch(_ context.Context, c *conn, _ string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return c.abortBatch()
 }
 
-func (s *statementExecutor) SetRetryAbortsInternally(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetRetryAbortsInternally(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	if params == "" {
 		return nil, spanner.ToSpannerError(status.Error(codes.InvalidArgument, "no value given for RetryAbortsInternally"))
 	}
@@ -168,19 +168,19 @@ func (s *statementExecutor) SetRetryAbortsInternally(_ context.Context, c *conn,
 	return c.setRetryAbortsInternally(retry)
 }
 
-func (s *statementExecutor) SetAutoBatchDml(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetAutoBatchDml(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return setBoolVariable("AutoBatchDml", func(value bool) (driver.Result, error) {
 		return driver.ResultNoRows, c.SetAutoBatchDml(value)
 	}, params)
 }
 
-func (s *statementExecutor) SetAutoBatchDmlUpdateCount(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetAutoBatchDmlUpdateCount(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return setInt64Variable("AutoBatchDmlUpdateCount", func(value int64) (driver.Result, error) {
 		return driver.ResultNoRows, c.SetAutoBatchDmlUpdateCount(value)
 	}, params)
 }
 
-func (s *statementExecutor) SetAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	return setBoolVariable("AutoBatchDmlUpdateCountVerification", func(value bool) (driver.Result, error) {
 		return driver.ResultNoRows, c.SetAutoBatchDmlUpdateCountVerification(value)
 	}, params)
@@ -208,7 +208,7 @@ func setInt64Variable(name string, f func(value int64) (driver.Result, error), p
 	return f(value)
 }
 
-func (s *statementExecutor) SetAutocommitDmlMode(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetAutocommitDmlMode(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	if params == "" {
 		return nil, spanner.ToSpannerError(status.Error(codes.InvalidArgument, "no value given for AutocommitDMLMode"))
 	}
@@ -224,7 +224,7 @@ func (s *statementExecutor) SetAutocommitDmlMode(_ context.Context, c *conn, par
 	return c.setAutocommitDMLMode(mode)
 }
 
-func (s *statementExecutor) SetExcludeTxnFromChangeStreams(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetExcludeTxnFromChangeStreams(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	if params == "" {
 		return nil, spanner.ToSpannerError(status.Error(codes.InvalidArgument, "no value given for ExcludeTxnFromChangeStreams"))
 	}
@@ -237,7 +237,7 @@ func (s *statementExecutor) SetExcludeTxnFromChangeStreams(_ context.Context, c 
 
 var maxCommitDelayRegexp = regexp.MustCompile(`(?i)^\s*('(?P<duration>(\d{1,19})(s|ms|us|ns))'|(?P<number>\d{1,19})|(?P<null>NULL))\s*$`)
 
-func (s *statementExecutor) SetMaxCommitDelay(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetMaxCommitDelay(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	duration, err := parseDuration(maxCommitDelayRegexp, "max_commit_delay", params)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ func (s *statementExecutor) SetMaxCommitDelay(_ context.Context, c *conn, params
 	return c.setMaxCommitDelay(duration)
 }
 
-func (s *statementExecutor) SetTransactionTag(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetTransactionTag(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	tag, err := parseTag(params)
 	if err != nil {
 		return nil, err
@@ -253,7 +253,7 @@ func (s *statementExecutor) SetTransactionTag(_ context.Context, c *conn, params
 	return c.setTransactionTag(tag)
 }
 
-func (s *statementExecutor) SetStatementTag(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetStatementTag(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	tag, err := parseTag(params)
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ var maxStalenessRegexp = regexp.MustCompile(`(?i)'(?P<type>MAX_STALENESS)[\t ]+(
 var readTimestampRegexp = regexp.MustCompile(`(?i)'(?P<type>READ_TIMESTAMP)[\t ]+(?P<timestamp>(\d{4})-(\d{2})-(\d{2})([Tt](\d{2}):(\d{2}):(\d{2})(\.\d{1,9})?)([Zz]|([+-])(\d{2}):(\d{2})))'`)
 var minReadTimestampRegexp = regexp.MustCompile(`(?i)'(?P<type>MIN_READ_TIMESTAMP)[\t ]+(?P<timestamp>(\d{4})-(\d{2})-(\d{2})([Tt](\d{2}):(\d{2}):(\d{2})(\.\d{1,9})?)([Zz]|([+-])(\d{2}):(\d{2})))'`)
 
-func (s *statementExecutor) SetReadOnlyStaleness(_ context.Context, c *conn, params string, _ []driver.NamedValue) (driver.Result, error) {
+func (s *statementExecutor) SetReadOnlyStaleness(_ context.Context, c *conn, params string, _ ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
 	if params == "" {
 		return nil, spanner.ToSpannerError(status.Error(codes.InvalidArgument, "no value given for ReadOnlyStaleness"))
 	}
@@ -369,6 +369,17 @@ func matchesToMap(re *regexp.Regexp, s string) map[string]string {
 	return matches
 }
 
+func createEmptyIterator() *clientSideIterator {
+	return &clientSideIterator{
+		metadata: &spannerpb.ResultSetMetadata{
+			RowType: &spannerpb.StructType{
+				Fields: []*spannerpb.StructType_Field{},
+			},
+		},
+		rows: []*spanner.Row{},
+	}
+}
+
 // createBooleanIterator creates a row iterator with a single BOOL column with
 // one row. This is used for client side statements that return a result set
 // containing a BOOL value.
@@ -428,7 +439,7 @@ type clientSideIterator struct {
 
 func (t *clientSideIterator) Next() (*spanner.Row, error) {
 	if t.index == len(t.rows) {
-		return nil, io.EOF
+		return nil, iterator.Done
 	}
 	row := t.rows[t.index]
 	t.index++

--- a/client_side_statement_test.go
+++ b/client_side_statement_test.go
@@ -22,8 +22,11 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestStatementExecutor_StartBatchDdl(t *testing.T) {
@@ -34,16 +37,16 @@ func TestStatementExecutor_StartBatchDdl(t *testing.T) {
 	if c.InDDLBatch() {
 		t.Fatal("connection unexpectedly in a DDL batch")
 	}
-	if _, err := s.StartBatchDdl(ctx, c, "", nil); err != nil {
+	if _, err := s.StartBatchDdl(ctx, c, "", ExecOptions{}, nil); err != nil {
 		t.Fatalf("could not start a DDL batch: %v", err)
 	}
 	if !c.InDDLBatch() {
 		t.Fatal("connection unexpectedly not in a DDL batch")
 	}
-	if _, err := s.StartBatchDdl(ctx, c, "", nil); spanner.ErrCode(err) != codes.FailedPrecondition {
+	if _, err := s.StartBatchDdl(ctx, c, "", ExecOptions{}, nil); spanner.ErrCode(err) != codes.FailedPrecondition {
 		t.Fatalf("error mismatch for starting a DDL batch while already in a batch\nGot: %v\nWant: %v", spanner.ErrCode(err), codes.FailedPrecondition)
 	}
-	if _, err := s.RunBatch(ctx, c, "", nil); err != nil {
+	if _, err := s.RunBatch(ctx, c, "", ExecOptions{}, nil); err != nil {
 		t.Fatalf("could not run empty DDL batch: %v", err)
 	}
 	if c.InDDLBatch() {
@@ -52,7 +55,7 @@ func TestStatementExecutor_StartBatchDdl(t *testing.T) {
 
 	// Starting a DDL batch while the connection is in a transaction is not allowed.
 	c.tx = &readWriteTransaction{}
-	if _, err := s.StartBatchDdl(ctx, c, "", nil); spanner.ErrCode(err) != codes.FailedPrecondition {
+	if _, err := s.StartBatchDdl(ctx, c, "", ExecOptions{}, nil); spanner.ErrCode(err) != codes.FailedPrecondition {
 		t.Fatalf("error mismatch for starting a DDL batch while in a transaction\nGot: %v\nWant: %v", spanner.ErrCode(err), codes.FailedPrecondition)
 	}
 }
@@ -65,16 +68,16 @@ func TestStatementExecutor_StartBatchDml(t *testing.T) {
 	if c.InDMLBatch() {
 		t.Fatal("connection unexpectedly in a DML batch")
 	}
-	if _, err := s.StartBatchDml(ctx, c, "", nil); err != nil {
+	if _, err := s.StartBatchDml(ctx, c, "", ExecOptions{}, nil); err != nil {
 		t.Fatalf("could not start a DML batch: %v", err)
 	}
 	if !c.InDMLBatch() {
 		t.Fatal("connection unexpectedly not in a DML batch")
 	}
-	if _, err := s.StartBatchDml(ctx, c, "", nil); spanner.ErrCode(err) != codes.FailedPrecondition {
+	if _, err := s.StartBatchDml(ctx, c, "", ExecOptions{}, nil); spanner.ErrCode(err) != codes.FailedPrecondition {
 		t.Fatalf("error mismatch for starting a DML batch while already in a batch\nGot: %v\nWant: %v", spanner.ErrCode(err), codes.FailedPrecondition)
 	}
-	if _, err := s.RunBatch(ctx, c, "", nil); err != nil {
+	if _, err := s.RunBatch(ctx, c, "", ExecOptions{}, nil); err != nil {
 		t.Fatalf("could not run empty DML batch: %v", err)
 	}
 	if c.InDMLBatch() {
@@ -83,13 +86,13 @@ func TestStatementExecutor_StartBatchDml(t *testing.T) {
 
 	// Starting a DML batch while the connection is in a read-only transaction is not allowed.
 	c.tx = &readOnlyTransaction{logger: noopLogger}
-	if _, err := s.StartBatchDml(ctx, c, "", nil); spanner.ErrCode(err) != codes.FailedPrecondition {
+	if _, err := s.StartBatchDml(ctx, c, "", ExecOptions{}, nil); spanner.ErrCode(err) != codes.FailedPrecondition {
 		t.Fatalf("error mismatch for starting a DML batch while in a read-only transaction\nGot: %v\nWant: %v", spanner.ErrCode(err), codes.FailedPrecondition)
 	}
 
 	// Starting a DML batch while the connection is in a read/write transaction is allowed.
 	c.tx = &readWriteTransaction{logger: noopLogger}
-	if _, err := s.StartBatchDml(ctx, c, "", nil); err != nil {
+	if _, err := s.StartBatchDml(ctx, c, "", ExecOptions{}, nil); err != nil {
 		t.Fatalf("could not start a DML batch while in a read/write transaction: %v", err)
 	}
 }
@@ -112,7 +115,7 @@ func TestStatementExecutor_RetryAbortsInternally(t *testing.T) {
 		{true, "fasle", true},
 		{true, "truye", true},
 	} {
-		it, err := s.ShowRetryAbortsInternally(ctx, c, "", nil)
+		it, err := s.ShowRetryAbortsInternally(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current retry value from connection: %v", i, err)
 		}
@@ -134,7 +137,7 @@ func TestStatementExecutor_RetryAbortsInternally(t *testing.T) {
 		}
 
 		// Set the next value.
-		res, err := s.SetRetryAbortsInternally(ctx, c, test.setValue, nil)
+		res, err := s.SetRetryAbortsInternally(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -169,7 +172,7 @@ func TestStatementExecutor_AutocommitDmlMode(t *testing.T) {
 		{Transactional, "'PartitionedNonAtomic'", true},
 		{Transactional, "'Transaction'", true},
 	} {
-		it, err := s.ShowAutocommitDmlMode(ctx, c, "", nil)
+		it, err := s.ShowAutocommitDmlMode(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current autocommit dml mode value from connection: %v", i, err)
 		}
@@ -191,7 +194,7 @@ func TestStatementExecutor_AutocommitDmlMode(t *testing.T) {
 		}
 
 		// Set the next value.
-		res, err := s.SetAutocommitDmlMode(ctx, c, test.setValue, nil)
+		res, err := s.SetAutocommitDmlMode(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -239,7 +242,7 @@ func TestStatementExecutor_ReadOnlyStaleness(t *testing.T) {
 		{spanner.StrongRead(), "'Min_Read_Timestamp'", true},
 		{spanner.StrongRead(), "'Min_Read_Timestamp 2021-10-08 09:14:30Z'", true},
 	} {
-		res, err := s.SetReadOnlyStaleness(ctx, c, test.setValue, nil)
+		res, err := s.SetReadOnlyStaleness(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -253,7 +256,7 @@ func TestStatementExecutor_ReadOnlyStaleness(t *testing.T) {
 			}
 		}
 
-		it, err := s.ShowReadOnlyStaleness(ctx, c, "", nil)
+		it, err := s.ShowReadOnlyStaleness(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current read-only staleness value from connection: %v", i, err)
 		}
@@ -292,7 +295,7 @@ func TestShowCommitTimestamp(t *testing.T) {
 	} {
 		c.commitTs = test.wantValue
 
-		it, err := s.ShowCommitTimestamp(ctx, c, "", nil)
+		it, err := s.ShowCommitTimestamp(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("could not get current commit timestamp from connection: %v", err)
 		}
@@ -338,7 +341,7 @@ func TestStatementExecutor_ExcludeTxnFromChangeStreams(t *testing.T) {
 		{true, "fasle", true},
 		{true, "truye", true},
 	} {
-		it, err := s.ShowExcludeTxnFromChangeStreams(ctx, c, "", nil)
+		it, err := s.ShowExcludeTxnFromChangeStreams(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current exclude value from connection: %v", i, err)
 		}
@@ -360,7 +363,7 @@ func TestStatementExecutor_ExcludeTxnFromChangeStreams(t *testing.T) {
 		}
 
 		// Set the next value.
-		res, err := s.SetExcludeTxnFromChangeStreams(ctx, c, test.setValue, nil)
+		res, err := s.SetExcludeTxnFromChangeStreams(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -399,7 +402,7 @@ func TestStatementExecutor_MaxCommitDelay(t *testing.T) {
 		{100 * time.Millisecond, "'10ms", true},
 		{100 * time.Millisecond, "10ms'", true},
 	} {
-		res, err := s.SetMaxCommitDelay(ctx, c, test.setValue, nil)
+		res, err := s.SetMaxCommitDelay(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -413,7 +416,7 @@ func TestStatementExecutor_MaxCommitDelay(t *testing.T) {
 			}
 		}
 
-		it, err := s.ShowMaxCommitDelay(ctx, c, "", nil)
+		it, err := s.ShowMaxCommitDelay(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current max_commit_delay value from connection: %v", i, err)
 		}
@@ -453,7 +456,7 @@ func TestStatementExecutor_SetTransactionTag(t *testing.T) {
 		c := &conn{retryAborts: true, logger: noopLogger}
 		s := &statementExecutor{}
 
-		it, err := s.ShowTransactionTag(ctx, c, "", nil)
+		it, err := s.ShowTransactionTag(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current transaction tag value from connection: %v", i, err)
 		}
@@ -475,7 +478,7 @@ func TestStatementExecutor_SetTransactionTag(t *testing.T) {
 		}
 
 		// Set a transaction tag.
-		res, err := s.SetTransactionTag(ctx, c, test.setValue, nil)
+		res, err := s.SetTransactionTag(ctx, c, test.setValue, ExecOptions{}, nil)
 		if test.wantSetErr {
 			if err == nil {
 				t.Fatalf("%d: missing expected error for value %q", i, test.setValue)
@@ -490,7 +493,7 @@ func TestStatementExecutor_SetTransactionTag(t *testing.T) {
 		}
 
 		// Get the tag that was set
-		it, err = s.ShowTransactionTag(ctx, c, "", nil)
+		it, err = s.ShowTransactionTag(ctx, c, "", ExecOptions{}, nil)
 		if err != nil {
 			t.Fatalf("%d: could not get current transaction tag value from connection: %v", i, err)
 		}
@@ -506,4 +509,101 @@ func TestStatementExecutor_SetTransactionTag(t *testing.T) {
 		}
 
 	}
+}
+
+func TestStatementExecutor_UsesExecOptions(t *testing.T) {
+	ctx := context.Background()
+	c := &conn{retryAborts: true, logger: noopLogger}
+	s := &statementExecutor{}
+
+	it, err := s.ShowTransactionTag(ctx, c, "", ExecOptions{DecodeOption: DecodeOptionProto, ReturnResultSetMetadata: true, ReturnResultSetStats: true}, nil)
+	if err != nil {
+		t.Fatalf("could not get current transaction tag value from connection: %v", err)
+	}
+	rows, ok := it.(driver.RowsNextResultSet)
+	if !ok {
+		t.Fatal("did not get RowsNextResultSet")
+	}
+	// The first result set contains the metadata.
+	cols := rows.Columns()
+	wantCols := []string{"metadata"}
+	if !cmp.Equal(cols, wantCols) {
+		t.Fatalf("column names mismatch\nGot: %v\nWant: %v", cols, wantCols)
+	}
+	wantValues := []driver.Value{&spannerpb.ResultSetMetadata{
+		RowType: &spannerpb.StructType{
+			Fields: []*spannerpb.StructType_Field{
+				{Name: "TransactionTag", Type: &spannerpb.Type{Code: spannerpb.TypeCode_STRING}},
+			},
+		},
+	}}
+	values := make([]driver.Value, len(cols))
+	if err := rows.Next(values); err != nil {
+		t.Fatalf("failed to get first row: %v", err)
+	}
+	if !cmp.Equal(values, wantValues, cmpopts.IgnoreUnexported(spannerpb.ResultSetMetadata{}, spannerpb.StructType{}, spannerpb.StructType_Field{}, spannerpb.Type{})) {
+		t.Fatalf("default transaction tag mismatch\nGot: %v\nWant: %v", values, wantValues)
+	}
+	if err := rows.Next(values); err != io.EOF {
+		t.Fatalf("error mismatch\nGot: %v\nWant: %v", err, io.EOF)
+	}
+
+	// Move to the next result set, which should contain the data.
+	if !rows.HasNextResultSet() {
+		t.Fatal("missing next result set")
+	}
+	if err := rows.NextResultSet(); err != nil {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", err, nil)
+	}
+
+	cols = rows.Columns()
+	wantCols = []string{"TransactionTag"}
+	if !cmp.Equal(cols, wantCols) {
+		t.Fatalf("column names mismatch\nGot: %v\nWant: %v", cols, wantCols)
+	}
+	values = make([]driver.Value, len(cols))
+	if err := rows.Next(values); err != nil {
+		t.Fatalf("failed to get first row: %v", err)
+	}
+	// The value that we get should be the raw protobuf value.
+	wantValues = []driver.Value{spanner.GenericColumnValue{
+		Type:  &spannerpb.Type{Code: spannerpb.TypeCode_STRING},
+		Value: &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: ""}},
+	}}
+	if !cmp.Equal(values, wantValues, cmpopts.IgnoreUnexported(spannerpb.Type{}, structpb.Value{})) {
+		t.Fatalf("default transaction tag mismatch\nGot: %v\nWant: %v", values, wantValues)
+	}
+	if err := rows.Next(values); err != io.EOF {
+		t.Fatalf("error mismatch\nGot: %v\nWant: %v", err, io.EOF)
+	}
+
+	// Move to the next result set, which should contain the ResultSetStats.
+	if !rows.HasNextResultSet() {
+		t.Fatal("missing next result set")
+	}
+	if err := rows.NextResultSet(); err != nil {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", err, nil)
+	}
+	cols = rows.Columns()
+	wantCols = []string{"stats"}
+	if !cmp.Equal(cols, wantCols) {
+		t.Fatalf("column names mismatch\nGot: %v\nWant: %v", cols, wantCols)
+	}
+	wantValues = []driver.Value{&spannerpb.ResultSetStats{}}
+	values = make([]driver.Value, len(cols))
+	if err := rows.Next(values); err != nil {
+		t.Fatalf("failed to get first row: %v", err)
+	}
+	if !cmp.Equal(values, wantValues, cmpopts.IgnoreUnexported(spannerpb.ResultSetStats{})) {
+		t.Fatalf("ResultSetStats mismatch\nGot: %v\nWant: %v", values, wantValues)
+	}
+	if err := rows.Next(values); err != io.EOF {
+		t.Fatalf("error mismatch\nGot: %v\nWant: %v", err, io.EOF)
+	}
+
+	// There should be no more result sets.
+	if rows.HasNextResultSet() {
+		t.Fatal("got unexpected next result set")
+	}
+
 }

--- a/conn.go
+++ b/conn.go
@@ -483,7 +483,7 @@ func (c *conn) startBatchDDL() (driver.Result, error) {
 }
 
 func (c *conn) startBatchDML(automatic bool) (driver.Result, error) {
-	execOptions := c.options()
+	execOptions := c.options( /*reset = */ true)
 
 	if c.inTransaction() {
 		return c.tx.StartBatchDML(execOptions.QueryOptions, automatic)
@@ -732,7 +732,7 @@ func (c *conn) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, error) {
-	execOptions := c.options()
+	execOptions := c.options( /* reset = */ true)
 	parsedSQL, args, err := c.parser.parseParameters(query)
 	if err != nil {
 		return nil, err
@@ -746,11 +746,11 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	if err != nil {
 		return nil, err
 	}
+	execOptions := c.options( /* reset = */ clientStmt == nil)
 	if clientStmt != nil {
-		return clientStmt.QueryContext(ctx, args)
+		return clientStmt.QueryContext(ctx, execOptions, args)
 	}
 
-	execOptions := c.options()
 	return c.queryContext(ctx, query, execOptions, args)
 }
 
@@ -801,13 +801,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions ExecO
 			return nil, err
 		}
 	}
-	res := &rows{
-		it:                      iter,
-		decodeOption:            execOptions.DecodeOption,
-		decodeToNativeArrays:    execOptions.DecodeToNativeArrays,
-		returnResultSetMetadata: execOptions.ReturnResultSetMetadata,
-		returnResultSetStats:    execOptions.ReturnResultSetStats,
-	}
+	res := createRows(iter, execOptions)
 	if execOptions.DirectExecuteQuery {
 		// This call to res.getColumns() triggers the execution of the statement, as it needs to fetch the metadata.
 		res.getColumns()
@@ -825,10 +819,10 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	if err != nil {
 		return nil, err
 	}
+	execOptions := c.options( /*reset = */ stmt == nil)
 	if stmt != nil {
-		return stmt.ExecContext(ctx, args)
+		return stmt.ExecContext(ctx, execOptions, args)
 	}
-	execOptions := c.options()
 	return c.execContext(ctx, query, execOptions, args)
 }
 
@@ -893,12 +887,14 @@ func (c *conn) execContext(ctx context.Context, query string, execOptions ExecOp
 	return res, nil
 }
 
-// options returns and resets the ExecOptions for the next statement.
-func (c *conn) options() ExecOptions {
-	defer func() {
-		c.execOptions.TransactionOptions.TransactionTag = ""
-		c.execOptions.QueryOptions.RequestTag = ""
-	}()
+// options returns and optionally resets the ExecOptions for the next statement.
+func (c *conn) options(reset bool) ExecOptions {
+	if reset {
+		defer func() {
+			c.execOptions.TransactionOptions.TransactionTag = ""
+			c.execOptions.QueryOptions.RequestTag = ""
+		}()
+	}
 	return c.execOptions
 }
 

--- a/rows.go
+++ b/rows.go
@@ -41,6 +41,16 @@ const (
 
 var _ driver.RowsNextResultSet = &rows{}
 
+func createRows(it rowIterator, opts ExecOptions) *rows {
+	return &rows{
+		it:                      it,
+		decodeOption:            opts.DecodeOption,
+		decodeToNativeArrays:    opts.DecodeToNativeArrays,
+		returnResultSetMetadata: opts.ReturnResultSetMetadata,
+		returnResultSetStats:    opts.ReturnResultSetStats,
+	}
+}
+
 type rows struct {
 	it    rowIterator
 	close func() error


### PR DESCRIPTION
Return ResultSetMetadata and ResultSetStats as separate result sets if the caller has requested this in the ExecOptions. This ensures that client-side statements behave the same as statements that are executed by Spanner.