### PR TITLE
feat: use a single multiplexed session for all operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ tx.QueryContext(ctx, "SELECT SingerId, Name FROM Singers WHERE SingerId = ?", 12
 
 ## Transactions
 
-- Read-write transactions always uses the strongest isolation level and ignore the user-specified level.
+- Read-write transactions support isolation levels `Serializable`, `Snapshot` and `RepeatableRead`.
 - Read-only transactions do strong-reads by default. Read-only transactions must be ended by calling
   either Commit or Rollback. Calling either of these methods will end the current read-only
-  transaction and return the session that is used to the session pool.
+  transaction.
 
 ```go
 tx, err := db.BeginTx(ctx, &sql.TxOptions{}) // Read-write transaction.
@@ -225,6 +225,11 @@ emulator.
 $ gcloud beta emulators spanner start
 $ export SPANNER_EMULATOR_HOST=localhost:9010
 ```
+
+### Automatically Create Instance and Database on the Emulator
+You can also add the `autoConfigEmulator=true` option to the connection string. This will instruct the driver
+to connect to the Spanner emulator, and to automatically create the Spanner instance and database on the
+emulator. See [examples/emulator](examples/emulator) for a working example.
 
 ## Spanner PostgreSQL Interface
 

--- a/driver.go
+++ b/driver.go
@@ -84,8 +84,8 @@ var noopLogger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{L
 //     The default is false
 //     - enableEndToEndTracing: Boolean that indicates if end-to-end tracing is enabled
 //     The default is false
-//     - minSessions: The minimum number of sessions in the backing session pool. The default is 100.
-//     - maxSessions: The maximum number of sessions in the backing session pool. The default is 400.
+//     - minSessions (DEPRECATED): The minimum number of sessions in the backing session pool. The default is 100. This option is deprecated, as the driver by default uses a single multiplexed session for all operations.
+//     - maxSessions (DEPRECATED): The maximum number of sessions in the backing session pool. The default is 400. This option is deprecated, as the driver by default uses a single multiplexed session for all operations.
 //     - numChannels: The number of gRPC channels to use to communicate with Cloud Spanner. The default is 4.
 //     - optimizerVersion: Sets the default query optimizer version to use for this connection.
 //     - optimizerStatisticsPackage: Sets the default query optimizer statistic package to use for this connection.


### PR DESCRIPTION
The Spanner database/sql driver now uses a single multiplexed session for all operations. Setting a value for MinSessions and MaxSessions is therefore no longer necessary for workloads that have a significantly higher or lower usage than can normally be served by the default session pool.

One multiplexed session can execute any number of both read-only and read/write transactions concurrently.

See https://cloud.google.com/spanner/docs/sessions#multiplexed_sessions for more information on multiplexed sessions.