### PR TITLE
chore: use generic set/show parser for auto_batch_dml

### DIFF
--- a/client_side_statement.go
+++ b/client_side_statement.go
@@ -69,30 +69,6 @@ func (s *statementExecutor) ShowRetryAbortsInternally(_ context.Context, c *conn
 	return createRows(it, opts), nil
 }
 
-func (s *statementExecutor) ShowAutoBatchDml(_ context.Context, c *conn, _ string, opts *ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
-	it, err := createBooleanIterator("AutoBatchDml", c.AutoBatchDml())
-	if err != nil {
-		return nil, err
-	}
-	return createRows(it, opts), nil
-}
-
-func (s *statementExecutor) ShowAutoBatchDmlUpdateCount(_ context.Context, c *conn, _ string, opts *ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
-	it, err := createInt64Iterator("AutoBatchDmlUpdateCount", c.AutoBatchDmlUpdateCount())
-	if err != nil {
-		return nil, err
-	}
-	return createRows(it, opts), nil
-}
-
-func (s *statementExecutor) ShowAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, opts *ExecOptions, _ string, _ []driver.NamedValue) (driver.Rows, error) {
-	it, err := createBooleanIterator("AutoBatchDmlUpdateCountVerification", c.AutoBatchDmlUpdateCountVerification())
-	if err != nil {
-		return nil, err
-	}
-	return createRows(it, opts), nil
-}
-
 func (s *statementExecutor) ShowAutocommitDmlMode(_ context.Context, c *conn, _ string, opts *ExecOptions, _ []driver.NamedValue) (driver.Rows, error) {
 	it, err := createStringIterator("AutocommitDMLMode", c.AutocommitDMLMode().String())
 	if err != nil {
@@ -134,46 +110,6 @@ func (s *statementExecutor) SetRetryAbortsInternally(_ context.Context, c *conn,
 		return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid boolean value: %s", params))
 	}
 	return c.setRetryAbortsInternally(retry)
-}
-
-func (s *statementExecutor) SetAutoBatchDml(_ context.Context, c *conn, params string, _ *ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
-	return setBoolVariable("AutoBatchDml", func(value bool) (driver.Result, error) {
-		return driver.ResultNoRows, c.SetAutoBatchDml(value)
-	}, params)
-}
-
-func (s *statementExecutor) SetAutoBatchDmlUpdateCount(_ context.Context, c *conn, params string, _ *ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
-	return setInt64Variable("AutoBatchDmlUpdateCount", func(value int64) (driver.Result, error) {
-		return driver.ResultNoRows, c.SetAutoBatchDmlUpdateCount(value)
-	}, params)
-}
-
-func (s *statementExecutor) SetAutoBatchDmlUpdateCountVerification(_ context.Context, c *conn, params string, _ *ExecOptions, _ []driver.NamedValue) (driver.Result, error) {
-	return setBoolVariable("AutoBatchDmlUpdateCountVerification", func(value bool) (driver.Result, error) {
-		return driver.ResultNoRows, c.SetAutoBatchDmlUpdateCountVerification(value)
-	}, params)
-}
-
-func setBoolVariable(name string, f func(value bool) (driver.Result, error), params string) (driver.Result, error) {
-	if params == "" {
-		return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "no value given for %s", name))
-	}
-	value, err := strconv.ParseBool(params)
-	if err != nil {
-		return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid boolean value: %s", params))
-	}
-	return f(value)
-}
-
-func setInt64Variable(name string, f func(value int64) (driver.Result, error), params string) (driver.Result, error) {
-	if params == "" {
-		return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "no value given for %s", name))
-	}
-	value, err := strconv.ParseInt(params, 10, 64)
-	if err != nil {
-		return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid int64 value: %s", params))
-	}
-	return f(value)
 }
 
 func (s *statementExecutor) SetAutocommitDmlMode(_ context.Context, c *conn, params string, _ *ExecOptions, _ []driver.NamedValue) (driver.Result, error) {

--- a/client_side_statements_json.go
+++ b/client_side_statements_json.go
@@ -35,33 +35,6 @@ var jsonFile = `{
       "exampleStatements": ["show variable retry_aborts_internally"],
       "examplePrerequisiteStatements": ["set readonly=false", "set autocommit=false"]
     },
-	{
-	  "name": "SHOW VARIABLE AUTO_BATCH_DML",
-	  "executorName": "ClientSideStatementNoParamExecutor",
-	  "resultType": "RESULT_SET",
-	  "statementType": "SHOW_AUTO_BATCH_DML",
-	  "regex": "(?is)\\A\\s*show\\s+variable\\s+auto_batch_dml\\s*\\z",
-	  "method": "statementShowAutoBatchDml",
-	  "exampleStatements": ["show variable auto_batch_dml"]
-	},
-	{
-	  "name": "SHOW VARIABLE AUTO_BATCH_DML_UPDATE_COUNT",
-	  "executorName": "ClientSideStatementNoParamExecutor",
-	  "resultType": "RESULT_SET",
-	  "statementType": "SHOW_AUTO_BATCH_DML_UPDATE_COUNT",
-	  "regex": "(?is)\\A\\s*show\\s+variable\\s+auto_batch_dml_update_count\\s*\\z",
-	  "method": "statementShowAutoBatchDmlUpdateCount",
-	  "exampleStatements": ["show variable auto_batch_dml_update_count"]
-	},
-	{
-	  "name": "SHOW VARIABLE AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION",
-	  "executorName": "ClientSideStatementNoParamExecutor",
-	  "resultType": "RESULT_SET",
-	  "statementType": "SHOW_AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION",
-	  "regex": "(?is)\\A\\s*show\\s+variable\\s+auto_batch_dml_update_count_verification\\s*\\z",
-	  "method": "statementShowAutoBatchDmlUpdateCountVerification",
-	  "exampleStatements": ["show variable auto_batch_dml_update_count_verification"]
-	},
     {
       "name": "SHOW VARIABLE AUTOCOMMIT_DML_MODE",
       "executorName": "ClientSideStatementNoParamExecutor",
@@ -127,51 +100,6 @@ var jsonFile = `{
         "converterName": "ClientSideStatementValueConverters$BooleanConverter"
       }
     },
-	{
-	  "name": "SET AUTO_BATCH_DML = TRUE|FALSE",
-	  "executorName": "ClientSideStatementSetExecutor",
-	  "resultType": "NO_RESULT",
-	  "statementType": "SET_AUTO_BATCH_DML",
-	  "regex": "(?is)\\A\\s*set\\s+auto_batch_dml\\s*(?:=)\\s*(.*)\\z",
-	  "method": "statementSetAutoBatchDml",
-	  "exampleStatements": ["set auto_batch_dml = true", "set auto_batch_dml = false"],
-	  "setStatement": {
-	    "propertyName": "AUTO_BATCH_DML",
-	    "separator": "=",
-	    "allowedValues": "(TRUE|FALSE)",
-	    "converterName": "ClientSideStatementValueConverters$BooleanConverter"
-	  }
-	},
-	{
-	  "name": "SET AUTO_BATCH_DML_UPDATE_COUNT = <INT64>",
-	  "executorName": "ClientSideStatementSetExecutor",
-	  "resultType": "NO_RESULT",
-	  "statementType": "SET_AUTO_BATCH_DML_UPDATE_COUNT",
-	  "regex": "(?is)\\A\\s*set\\s+auto_batch_dml_update_count\\s*(?:=)\\s*(.*)\\z",
-	  "method": "statementSetAutoBatchDmlUpdateCount",
-	  "exampleStatements": ["set auto_batch_dml_update_count = 0", "set auto_batch_dml_update_count = 100"],
-	  "setStatement": {
-	    "propertyName": "AUTO_BATCH_DML_UPDATE_COUNT",
-	    "separator": "=",
-	    "allowedValues": "(\\d{1,19})",
-	    "converterName": "ClientSideStatementValueConverters$LongConverter"
-	  }
-	},
-	{
-	  "name": "SET AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION = TRUE|FALSE",
-	  "executorName": "ClientSideStatementSetExecutor",
-	  "resultType": "NO_RESULT",
-	  "statementType": "SET_AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION",
-	  "regex": "(?is)\\A\\s*set\\s+auto_batch_dml_update_count_verification\\s*(?:=)\\s*(.*)\\z",
-	  "method": "statementSetAutoBatchDmlUpdateCountVerification",
-	  "exampleStatements": ["set auto_batch_dml_update_count_verification = true", "set auto_batch_dml_update_count_verification = false"],
-	  "setStatement": {
-	    "propertyName": "AUTO_BATCH_DML_UPDATE_COUNT_VERIFICATION",
-	    "separator": "=",
-	    "allowedValues": "(TRUE|FALSE)",
-	    "converterName": "ClientSideStatementValueConverters$BooleanConverter"
-	  }
-	},
     {
       "name": "SET AUTOCOMMIT_DML_MODE = 'PARTITIONED_NON_ATOMIC'|'TRANSACTIONAL'",
       "executorName": "ClientSideStatementSetExecutor",


### PR DESCRIPTION
Remove the regex-based statements for auto_batch_dml variables. This automatically causes them to fall back to the generic SET and SHOW statements, and reduces the amount of code needed.

These statements are already covered by existing tests, which is why this change does not add any new tests for this.