### PR TITLE
chore: remove regex-based BATCH statements

### DIFF
--- a/client_side_statements_json.go
+++ b/client_side_statements_json.go
@@ -42,40 +42,6 @@ var jsonFile = `{
       "method": "statementShowReadOnlyStaleness",
       "exampleStatements": ["show variable read_only_staleness"]
     },
-	{
-      "name": "START BATCH DDL",
-      "executorName": "ClientSideStatementNoParamExecutor",
-      "resultType": "NO_RESULT",
-      "regex": "(?is)\\A\\s*(?:start)(?:\\s+batch)(?:\\s+ddl)\\s*\\z",
-      "method": "statementStartBatchDdl",
-      "exampleStatements": ["start batch ddl"]
-    },
-    {
-      "name": "START BATCH DML",
-      "executorName": "ClientSideStatementNoParamExecutor",
-      "resultType": "NO_RESULT",
-      "regex": "(?is)\\A\\s*(?:start)(?:\\s+batch)(?:\\s+dml)\\s*\\z",
-      "method": "statementStartBatchDml",
-      "exampleStatements": ["start batch dml"]
-    },
-    {
-      "name": "RUN BATCH",
-      "executorName": "ClientSideStatementNoParamExecutor",
-      "resultType": "NO_RESULT",
-      "regex": "(?is)\\A\\s*(?:run)(?:\\s+batch)\\s*\\z",
-      "method": "statementRunBatch",
-      "exampleStatements": ["run batch"],
-      "examplePrerequisiteStatements": ["start batch ddl"]
-    },
-    {
-      "name": "ABORT BATCH",
-      "executorName": "ClientSideStatementNoParamExecutor",
-      "resultType": "NO_RESULT",
-      "regex": "(?is)\\A\\s*(?:abort)(?:\\s+batch)\\s*\\z",
-      "method": "statementAbortBatch",
-      "exampleStatements": ["abort batch"],
-      "examplePrerequisiteStatements": ["start batch ddl"]
-    },
     {
       "name": "SET RETRY_ABORTS_INTERNALLY = TRUE|FALSE",
       "executorName": "ClientSideStatementSetExecutor",

--- a/statement_parser.go
+++ b/statement_parser.go
@@ -55,6 +55,9 @@ var dropStatements = map[string]bool{"DROP": true}
 var showStatements = map[string]bool{"SHOW": true}
 var setStatements = map[string]bool{"SET": true}
 var resetStatements = map[string]bool{"RESET": true}
+var startStatements = map[string]bool{"START": true}
+var runStatements = map[string]bool{"RUN": true}
+var abortStatements = map[string]bool{"ABORT": true}
 
 func union(m1 map[string]bool, m2 map[string]bool) map[string]bool {
 	res := make(map[string]bool, len(m1)+len(m2))
@@ -289,6 +292,20 @@ func (p *simpleParser) eatLiteral() (literal, error) {
 		return literal{}, status.Errorf(codes.InvalidArgument, "missing literal at position %d", p.pos)
 	}
 	return literal{value: value}, nil
+}
+
+// eatKeywords eats the given keywords in the order of the slice.
+// Returns true and updates the position of the parser if all the keywords were successfully eaten.
+// Returns false and does not update the position of the parser if not all keywords could be eaten.
+func (p *simpleParser) eatKeywords(keywords []string) bool {
+	startPos := p.pos
+	for _, keyword := range keywords {
+		if _, ok := p.eatKeyword(keyword); !ok {
+			p.pos = startPos
+			return false
+		}
+	}
+	return true
 }
 
 // eatKeyword eats the given keyword at the current position of the parser if it exists.
@@ -1006,6 +1023,18 @@ func isSetStatementKeyword(keyword string) bool {
 
 func isResetStatementKeyword(keyword string) bool {
 	return isStatementKeyword(keyword, resetStatements)
+}
+
+func isStartStatementKeyword(keyword string) bool {
+	return isStatementKeyword(keyword, startStatements)
+}
+
+func isRunStatementKeyword(keyword string) bool {
+	return isStatementKeyword(keyword, runStatements)
+}
+
+func isAbortStatementKeyword(keyword string) bool {
+	return isStatementKeyword(keyword, abortStatements)
 }
 
 func isStatementKeyword(keyword string, keywords map[string]bool) bool {

--- a/statement_parser_test.go
+++ b/statement_parser_test.go
@@ -1559,31 +1559,31 @@ func TestParseClientSideStatement(t *testing.T) {
 		{
 			name:  "Start DDL batch",
 			input: "START BATCH DDL",
-			want:  "START BATCH DDL",
+			want:  "START BATCH",
 			exec:  true,
 		},
 		{
 			name:  "Start DDL batch using line feeds",
 			input: "START\nBATCH\nDDL",
-			want:  "START BATCH DDL",
+			want:  "START BATCH",
 			exec:  true,
 		},
 		{
 			name:  "Start DDL batch lower case",
 			input: "start batch ddl",
-			want:  "START BATCH DDL",
+			want:  "START BATCH",
 			exec:  true,
 		},
 		{
 			name:  "Start DDL batch with extra spaces",
 			input: "\tSTART  BATCH\n\nDDL",
-			want:  "START BATCH DDL",
+			want:  "START BATCH",
 			exec:  true,
 		},
 		{
 			name:  "Start DML batch",
 			input: "START BATCH DML",
-			want:  "START BATCH DML",
+			want:  "START BATCH",
 			exec:  true,
 		},
 		{
@@ -1638,11 +1638,11 @@ func TestParseClientSideStatement(t *testing.T) {
 				got = statement.Name
 			}
 			if got != tc.want {
-				t.Errorf("parseClientSideStatement test failed: %s\nGot: %s\nWant: %s.", tc.name, got, tc.want)
+				t.Errorf("parseClientSideStatement test failed: %s\n Got: %s\nWant: %s.", tc.name, got, tc.want)
 			}
 			if tc.wantParams != "" {
 				if g, w := statement.params, tc.wantParams; g != w {
-					t.Errorf("params mismatch for %s\nGot: %v\nWant: %v", tc.name, g, w)
+					t.Errorf("params mismatch for %s\n Got: %v\nWant: %v", tc.name, g, w)
 				}
 			}
 		})


### PR DESCRIPTION
Replace the regex-based BATCH statements with statements that are parsed using the token-based parser. This will allow us to remove the entire regex-based parsing and related code.