### PR TITLE
test: move utility functions to testutil

### DIFF
--- a/aborted_transactions_test.go
+++ b/aborted_transactions_test.go
@@ -48,8 +48,8 @@ func TestCommitAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 2; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -92,8 +92,8 @@ func TestCommitWithMutationsAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 2; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -125,8 +125,8 @@ func TestCommitAbortedWithInternalRetriesDisabled(t *testing.T) {
 	if g, w := spanner.ErrCode(err), codes.Aborted; g != w {
 		t.Fatalf("commit error code mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -167,12 +167,12 @@ func TestUpdateAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -211,12 +211,12 @@ func TestBatchUpdateAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("batch request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -488,12 +488,12 @@ func testRetryReadWriteTransactionWithQuery(t *testing.T, setupServer func(serve
 	if err != wantCommitErr {
 		t.Fatalf("commit error mismatch\nGot: %v\nWant: %v", err, wantCommitErr)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execReqs), wantSqlExecuteCount; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), wantCommitCount; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -568,8 +568,8 @@ func TestQueryAbortedHalfway_WithDifferentResultsInFirstHalf(t *testing.T) {
 		t.Fatalf("failed to rollback transaction: %v", err)
 	}
 
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -651,8 +651,8 @@ func TestQueryAbortedHalfway_WithDifferentResultsInSecondHalf(t *testing.T) {
 		t.Fatalf("failed to commit transaction: %v", err)
 	}
 
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -702,14 +702,14 @@ func TestSecondUpdateAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	// The server should receive 4 execute statements, as each update statement should
 	// be executed twice.
 	if g, w := len(execReqs), 4; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -761,14 +761,14 @@ func TestSecondBatchUpdateAborted(t *testing.T) {
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	// The server should receive 4 batch statements, as each update statement should
 	// be executed twice.
 	if g, w := len(execReqs), 4; g != w {
 		t.Fatalf("batch request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -823,14 +823,14 @@ func TestSecondUpdateAborted_FirstStatementWithSameError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	// The server should receive 4 execute statements, as each update statement should
 	// be executed twice.
 	if g, w := len(execReqs), 4; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -912,8 +912,8 @@ func testSecondUpdateAborted_FirstResultChanged(t *testing.T, firstResult *testu
 	if err := tx.Rollback(); err != nil {
 		t.Fatalf("failed to rollback transaction: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	// The server should receive 3 execute statements, as only the first statement is retried.
 	if g, w := len(execReqs), 3; g != w {
 		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
@@ -973,12 +973,12 @@ func TestBatchUpdateAbortedWithError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit failed: %v", err)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("batch request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), 2; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -1037,12 +1037,12 @@ func TestBatchUpdateAbortedWithError_DifferentRowCountDuringRetry(t *testing.T) 
 	if err != ErrAbortedDueToConcurrentModification {
 		t.Fatalf("commit error mismatch\nGot: %v\nWant: %v", err, ErrAbortedDueToConcurrentModification)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(execReqs), 2; g != w {
 		t.Fatalf("batch request count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	// The commit should be attempted only once.
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
@@ -1096,8 +1096,8 @@ func TestBatchUpdateAbortedWithError_DifferentErrorDuringRetry(t *testing.T) {
 	if err != ErrAbortedDueToConcurrentModification {
 		t.Fatalf("commit error mismatch\n Got: %v\nWant: %v", err, ErrAbortedDueToConcurrentModification)
 	}
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	execReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	// There are 3 ExecuteBatchDmlRequests sent to Spanner:
 	// 1. An initial attempt with a BeginTransaction RPC, but this returns a NotFound error.
 	//    This causes the transaction to be retried with an explicit BeginTransaction request.
@@ -1106,7 +1106,7 @@ func TestBatchUpdateAbortedWithError_DifferentErrorDuringRetry(t *testing.T) {
 	if g, w := len(execReqs), 3; g != w {
 		t.Fatalf("batch request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	commitReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	// The commit should be attempted only once.
 	if g, w := len(commitReqs), 1; g != w {
 		t.Fatalf("commit request count mismatch\n Got: %v\nWant: %v", g, w)
@@ -1121,7 +1121,7 @@ func TestBatchUpdateAbortedWithError_DifferentErrorDuringRetry(t *testing.T) {
 	if req2.GetTransaction() == nil || req2.GetTransaction().GetId() == nil {
 		t.Fatal("the second ExecuteBatchDmlRequest should have a transaction id")
 	}
-	beginRequests := requestsOfType(reqs, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	beginRequests := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	if g, w := len(beginRequests), 2; g != w {
 		t.Fatalf("begin request count mismatch\n Got: %v\nWant: %v", g, w)
 	}

--- a/auto_dml_batch_test.go
+++ b/auto_dml_batch_test.go
@@ -49,8 +49,8 @@ func TestAutoBatchDml_Basics(t *testing.T) {
 			t.Fatalf("failed to commit: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 1; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -58,7 +58,7 @@ func TestAutoBatchDml_Basics(t *testing.T) {
 		if g, w := len(batchDmlRequest.Statements), 2; g != w {
 			t.Fatalf("num statements in batch requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -94,8 +94,8 @@ func TestAutoBatchDml_UpdateCount(t *testing.T) {
 			t.Fatalf("failed to commit: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 1; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -103,7 +103,7 @@ func TestAutoBatchDml_UpdateCount(t *testing.T) {
 		if g, w := len(batchDmlRequest.Statements), 2; g != w {
 			t.Fatalf("num statements in batch requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -135,8 +135,8 @@ func TestAutoBatchDml_UpdateCountVerificationFailsBeforeCommit(t *testing.T) {
 			t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 1; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -144,11 +144,11 @@ func TestAutoBatchDml_UpdateCountVerificationFailsBeforeCommit(t *testing.T) {
 		if g, w := len(batchDmlRequest.Statements), 1; g != w {
 			t.Fatalf("num statements in batch requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 0; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		rollbackRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
+		rollbackRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
 		if g, w := len(rollbackRequests), 1; g != w {
 			t.Fatalf("num rollback requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -183,8 +183,8 @@ func TestAutoBatchDml_UpdateCountVerificationFailsBeforeQuery(t *testing.T) {
 			t.Fatalf("failed to commit transaction: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 1; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -192,15 +192,15 @@ func TestAutoBatchDml_UpdateCountVerificationFailsBeforeQuery(t *testing.T) {
 		if g, w := len(batchDmlRequest.Statements), 1; g != w {
 			t.Fatalf("num statements in batch requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
 		if g, w := len(executeRequests), 0; g != w {
 			t.Fatalf("num ExecuteSql requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		rollbackRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
+		rollbackRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
 		if g, w := len(rollbackRequests), 0; g != w {
 			t.Fatalf("num rollback requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -218,18 +218,18 @@ func TestAutoBatchDml_OutsideTransaction(t *testing.T) {
 		execContext(t, ctx, db, insert, 1, 1)
 		execContext(t, ctx, db, insert, 1, 2)
 
-		requests := drainRequestsFromServer(server.TestSpanner)
+		requests := server.TestSpanner.DrainRequestsFromServer()
 		// DML auto-batching only works in transactions.
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 0; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
 		if g, w := len(executeRequests), 2; g != w {
 			t.Fatalf("num ExecuteSql requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
 		// Each statement is committed after execution, so we should see 2 commit requests.
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 2; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -255,16 +255,16 @@ func TestAutoBatchDml_FollowedByQuery(t *testing.T) {
 			t.Fatalf("failed to commit: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchDmlRequests), 1; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
 		if g, w := len(executeRequests), 1; g != w {
 			t.Fatalf("num ExecuteSql requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -289,25 +289,25 @@ func TestAutoBatchDml_FollowedByRollback(t *testing.T) {
 			t.Fatalf("failed to rollback: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		batchDmlRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
 		// The batch should be aborted and no requests should be sent to Spanner.
 		if g, w := len(batchDmlRequests), 0; g != w {
 			t.Fatalf("num BatchDML requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+		executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
 		if g, w := len(executeRequests), 0; g != w {
 			t.Fatalf("num ExecuteSql requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
 		if g, w := len(commitRequests), 0; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		beginRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+		beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
 		if g, w := len(beginRequests), 0; g != w {
 			t.Fatalf("num BeginTransaction requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		rollbackRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
+		rollbackRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.RollbackRequest{}))
 		// There are no rollback requests sent to Spanner, as the transaction is never started.
 		if g, w := len(rollbackRequests), 0; g != w {
 			t.Fatalf("num rollback requests mismatch\n Got: %v\nWant: %v", g, w)

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -214,8 +214,8 @@ func TestSimpleQuery(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -247,8 +247,8 @@ func TestDirectExecuteQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	// There should be no request on the server.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 0; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -256,8 +256,8 @@ func TestDirectExecuteQuery(t *testing.T) {
 		t.Fatal("no rows")
 	}
 	// The request should now be present on the server.
-	requests = drainRequestsFromServer(server.TestSpanner)
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -269,8 +269,8 @@ func TestDirectExecuteQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The request should be present on the server.
-	requests = drainRequestsFromServer(server.TestSpanner)
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -338,8 +338,8 @@ func TestSingleQueryWithTimestampBound(t *testing.T) {
 		t.Fatal(rows.Err())
 	}
 	_ = rows.Close()
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -370,8 +370,8 @@ func TestSingleQueryWithTimestampBound(t *testing.T) {
 		t.Fatal(rows.Err())
 	}
 	_ = rows.Close()
-	requests = drainRequestsFromServer(server.TestSpanner)
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -431,8 +431,8 @@ func TestSimpleReadOnlyTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -445,11 +445,11 @@ func TestSimpleReadOnlyTransaction(t *testing.T) {
 	}
 	// Read-only transactions are not really committed on Cloud Spanner, so
 	// there should be no commit request on the server.
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 0; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	beginReadOnlyRequests := filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	beginReadOnlyRequests := filterBeginReadOnlyRequests(testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
 	if g, w := len(beginReadOnlyRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -488,12 +488,12 @@ func TestReadOnlyTransactionWithStaleness(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginReadOnlyRequests := filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginReadOnlyRequests := filterBeginReadOnlyRequests(testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
 	if g, w := len(beginReadOnlyRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), 1; g != w {
 		t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -541,12 +541,12 @@ func TestReadOnlyTransactionWithOptions(t *testing.T) {
 	}
 	useTx(tx)
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginReadOnlyRequests := filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginReadOnlyRequests := filterBeginReadOnlyRequests(testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
 	if g, w := len(beginReadOnlyRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), 1; g != w {
 		t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -567,12 +567,12 @@ func TestReadOnlyTransactionWithOptions(t *testing.T) {
 	}
 	useTx(tx)
 
-	requests = drainRequestsFromServer(server.TestSpanner)
-	beginReadOnlyRequests = filterBeginReadOnlyRequests(requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	beginReadOnlyRequests = filterBeginReadOnlyRequests(testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{})))
 	if g, w := len(beginReadOnlyRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	executeRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	executeRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), 1; g != w {
 		t.Fatalf("execute requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -636,12 +636,12 @@ func TestSimpleReadWriteTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	if g, w := len(beginRequests), 0; g != w {
 		t.Fatalf("begin requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -655,7 +655,7 @@ func TestSimpleReadWriteTransaction(t *testing.T) {
 	if req.LastStatement {
 		t.Fatalf("last statement set for ExecuteSqlRequest")
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -705,8 +705,8 @@ func TestPreparedQuery(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -969,8 +969,8 @@ func TestQueryWithAllTypes(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -1419,8 +1419,8 @@ func TestQueryWithNullParameters(t *testing.T) {
 		if rows.Err() != nil {
 			t.Fatal(rows.Err())
 		}
-		requests := drainRequestsFromServer(server.TestSpanner)
-		sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(sqlRequests), 1; g != w {
 			t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 		}
@@ -1791,8 +1791,8 @@ func TestQueryWithAllNativeTypes(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -2039,8 +2039,8 @@ func TestDmlInAutocommit(t *testing.T) {
 	if g, w := affected, int64(testutil.UpdateBarSetFooRowCount); g != w {
 		t.Fatalf("row count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -2056,7 +2056,7 @@ func TestDmlInAutocommit(t *testing.T) {
 	if !req.LastStatement {
 		t.Fatal("missing LastStatement for ExecuteSqlRequest")
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -2085,8 +2085,8 @@ func TestQueryWithDuplicateNamedParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Verify that 'bar' is used for both instances of the parameter @name.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
@@ -2115,8 +2115,8 @@ func TestQueryWithReusedNamedParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Verify that 'foo' is used for both instances of the parameter @name.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
@@ -2145,8 +2145,8 @@ func TestQueryWithReusedPositionalParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Verify that 'bar' is used for both instances of the parameter @name.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
@@ -2175,8 +2175,8 @@ func TestQueryWithMissingPositionalParameter(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Verify that 'foo' is used for the parameter @name.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
@@ -2236,15 +2236,15 @@ func TestDmlReturningInAutocommit(t *testing.T) {
 		}
 
 		// Verify that a read/write transaction was used.
-		requests := drainRequestsFromServer(server.TestSpanner)
-		sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(sqlRequests), 1; g != w {
 			t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 		}
 		if !sqlRequests[0].(*sppb.ExecuteSqlRequest).LastStatement {
 			t.Fatal("missing LastStatement for ExecuteSqlRequest")
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 		}
@@ -2391,8 +2391,8 @@ func TestApplyMutations(t *testing.T) {
 
 	// Even though the Apply method is used outside a transaction, the connection will internally start a read/write
 	// transaction for the mutations.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -2463,8 +2463,8 @@ func TestBufferWriteMutations(t *testing.T) {
 		t.Fatalf("failed to commit transaction: %v", err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -2728,8 +2728,8 @@ func TestPartitionedDml(t *testing.T) {
 	if affected != 200 {
 		t.Fatalf("affected rows mismatch\nGot: %v\nWant: %v", affected, 200)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	var beginPdml *sppb.BeginTransactionRequest
 	for _, req := range beginRequests {
 		if req.(*sppb.BeginTransactionRequest).Options.GetPartitionedDml() != nil {
@@ -2740,7 +2740,7 @@ func TestPartitionedDml(t *testing.T) {
 	if beginPdml == nil {
 		t.Fatal("no begin request for Partitioned DML found")
 	}
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
@@ -2798,12 +2798,12 @@ func TestAutocommitBatchDml(t *testing.T) {
 	}
 
 	// There should be no ExecuteSqlRequest statements on the server.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 0 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 0)
 	}
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if len(batchRequests) != 0 {
 		t.Fatalf("BatchDML requests count mismatch\nGot: %v\nWant: %v", len(batchRequests), 0)
 	}
@@ -2821,13 +2821,13 @@ func TestAutocommitBatchDml(t *testing.T) {
 		t.Fatalf("affected rows mismatch\nGot: %v\nWant: %v", affected, 2)
 	}
 
-	requests = drainRequestsFromServer(server.TestSpanner)
+	requests = server.TestSpanner.DrainRequestsFromServer()
 	// There should still be no ExecuteSqlRequests on the server.
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 0 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 0)
 	}
-	batchRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if len(batchRequests) != 1 {
 		t.Fatalf("BatchDML requests count mismatch\nGot: %v\nWant: %v", len(batchRequests), 1)
 	}
@@ -2835,7 +2835,7 @@ func TestAutocommitBatchDml(t *testing.T) {
 		t.Fatal("last statements flag not set")
 	}
 	// The transaction should also have been committed.
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if len(commitRequests) != 1 {
 		t.Fatalf("Commit requests count mismatch\nGot: %v\nWant: %v", len(commitRequests), 1)
 	}
@@ -2884,13 +2884,13 @@ func TestExecuteBatchDml(t *testing.T) {
 		t.Fatalf("affected batch rows mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// There should be no ExecuteSqlRequests on the server.
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 0; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(batchRequests), 1; g != w {
 		t.Fatalf("BatchDML requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -2898,7 +2898,7 @@ func TestExecuteBatchDml(t *testing.T) {
 		t.Fatal("last statements flag not set")
 	}
 	// The transaction should have been committed.
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("Commit requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -2931,13 +2931,13 @@ func TestExecuteBatchDmlError(t *testing.T) {
 		t.Fatalf("failed to execute dml batch: %v", err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// There should be no requests on the server.
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(batchRequests), 0; g != w {
 		t.Fatalf("BatchDML requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 0; g != w {
 		t.Fatalf("Commit requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3012,12 +3012,12 @@ func TestTransactionBatchDml(t *testing.T) {
 	}
 
 	// There should be no ExecuteSqlRequest statements on the server.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 0 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 0)
 	}
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if len(batchRequests) != 0 {
 		t.Fatalf("BatchDML requests count mismatch\nGot: %v\nWant: %v", len(batchRequests), 0)
 	}
@@ -3035,13 +3035,13 @@ func TestTransactionBatchDml(t *testing.T) {
 		t.Fatalf("affected rows mismatch\nGot: %v\nWant: %v", affected, 2)
 	}
 
-	requests = drainRequestsFromServer(server.TestSpanner)
+	requests = server.TestSpanner.DrainRequestsFromServer()
 	// There should still be no ExecuteSqlRequests on the server.
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 0 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 0)
 	}
-	batchRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if len(batchRequests) != 1 {
 		t.Fatalf("BatchDML requests count mismatch\nGot: %v\nWant: %v", len(batchRequests), 1)
 	}
@@ -3049,7 +3049,7 @@ func TestTransactionBatchDml(t *testing.T) {
 		t.Fatal("last statements flag set")
 	}
 	// The transaction should still be active.
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if len(commitRequests) != 0 {
 		t.Fatalf("Commit requests count mismatch\nGot: %v\nWant: %v", len(commitRequests), 0)
 	}
@@ -3067,19 +3067,19 @@ func TestTransactionBatchDml(t *testing.T) {
 		t.Fatalf("failed to commit transaction after batch: %v", err)
 	}
 
-	requests = drainRequestsFromServer(server.TestSpanner)
+	requests = server.TestSpanner.DrainRequestsFromServer()
 	// There should now be one ExecuteSqlRequests on the server.
-	sqlRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if len(sqlRequests) != 1 {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", len(sqlRequests), 1)
 	}
 	// There should be no new Batch DML requests.
-	batchRequests = requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if len(batchRequests) != 0 {
 		t.Fatalf("BatchDML requests count mismatch\nGot: %v\nWant: %v", len(batchRequests), 0)
 	}
 	// The transaction should now be committed.
-	commitRequests = requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if len(commitRequests) != 1 {
 		t.Fatalf("Commit requests count mismatch\nGot: %v\nWant: %v", len(commitRequests), 1)
 	}
@@ -3140,20 +3140,20 @@ func TestExecuteBatchDmlTransaction(t *testing.T) {
 		t.Fatalf("failed to commit transaction after batch: %v", err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// There should be no ExecuteSqlRequests on the server.
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 0; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(batchRequests), 1; g != w {
 		t.Fatalf("BatchDML requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
 	if batchRequests[0].(*sppb.ExecuteBatchDmlRequest).LastStatements {
 		t.Fatal("last statements flag was set, this should not happen for batches in a transaction")
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("Commit requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3466,8 +3466,8 @@ func TestMinSessions(t *testing.T) {
 	_ = db.Close()
 
 	// Verify that the connector created 10 sessions on the server.
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	createReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	createReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	numCreated := int32(0)
 	for _, req := range createReqs {
 		numCreated += req.(*sppb.BatchCreateSessionsRequest).SessionCount
@@ -3504,8 +3504,8 @@ func TestMaxSessions(t *testing.T) {
 	wg.Wait()
 
 	// Verify that the connector only created 2 sessions on the server.
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	createReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	createReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	numCreated := int32(0)
 	for _, req := range createReqs {
 		numCreated += req.(*sppb.BatchCreateSessionsRequest).SessionCount
@@ -3538,8 +3538,8 @@ func TestClientReuse(t *testing.T) {
 		_ = conn.Close()
 	}
 	// Verify that the connector only created 2 sessions on the server.
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	createReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	createReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	numCreated := int32(0)
 	for _, req := range createReqs {
 		numCreated += req.(*sppb.BatchCreateSessionsRequest).SessionCount
@@ -3563,8 +3563,8 @@ func TestClientReuse(t *testing.T) {
 	if err := db.QueryRowContext(ctx, "SELECT 1").Scan(&res); err != nil {
 		t.Fatalf("failed to execute query on db: %v", err)
 	}
-	reqs = drainRequestsFromServer(server.TestSpanner)
-	createReqs = requestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	reqs = server.TestSpanner.DrainRequestsFromServer()
+	createReqs = testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	numCreated = int32(0)
 	for _, req := range createReqs {
 		numCreated += req.(*sppb.BatchCreateSessionsRequest).SessionCount
@@ -3625,8 +3625,8 @@ func TestStressClientReuse(t *testing.T) {
 	wg.Wait()
 
 	// Verify that each unique connection string created numSessions (10) sessions on the server.
-	reqs := drainRequestsFromServer(server.TestSpanner)
-	createReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	reqs := server.TestSpanner.DrainRequestsFromServer()
+	createReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	numCreated := int32(0)
 	for _, req := range createReqs {
 		numCreated += req.(*sppb.BatchCreateSessionsRequest).SessionCount
@@ -3634,7 +3634,7 @@ func TestStressClientReuse(t *testing.T) {
 	if g, w := numCreated, int32(numSessions*numClients); g != w {
 		t.Errorf("session creation count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	sqlReqs := requestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	sqlReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlReqs), numClients*numParallel; g != w {
 		t.Errorf("ExecuteSql request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3670,8 +3670,8 @@ func TestExcludeTxnFromChangeStreams_AutoCommitUpdate(t *testing.T) {
 	if _, err = conn.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
 		t.Fatal(err)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -3717,8 +3717,8 @@ func TestExcludeTxnFromChangeStreams_AutoCommitBatchDml(t *testing.T) {
 	if _, err := conn.ExecContext(ctx, "run batch"); err != nil {
 		t.Fatal(err)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(batchRequests), 1; g != w {
 		t.Fatalf("ExecuteBatchDmlRequest count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -3761,8 +3761,8 @@ func TestExcludeTxnFromChangeStreams_PartitionedDml(t *testing.T) {
 	if _, err := conn.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
 		t.Fatal(err)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	if g, w := len(beginRequests), 1; g != w {
 		t.Fatalf("BeginTransactionRequest count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -3804,12 +3804,12 @@ func TestExcludeTxnFromChangeStreams_Transaction(t *testing.T) {
 	_, _ = conn.ExecContext(ctx, testutil.UpdateBarSetFoo)
 	_ = tx.Commit()
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	if g, w := len(beginRequests), 0; g != w {
 		t.Fatalf("BeginTransactionRequest count mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequest count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3860,9 +3860,9 @@ func TestTag_Query_AutoCommit(t *testing.T) {
 	}
 	_ = iter.Close()
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// The ExecuteSqlRequest and CommitRequest should have a transaction tag.
-	execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execRequests), 1; g != w {
 		t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3905,9 +3905,9 @@ func TestTag_Update_AutoCommit(t *testing.T) {
 	_, _ = conn.ExecContext(ctx, "set statement_tag = 'tag_1'")
 	_, _ = conn.ExecContext(ctx, testutil.UpdateBarSetFoo)
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// The ExecuteSqlRequest and CommitRequest should have a transaction tag.
-	execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execRequests), 1; g != w {
 		t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3918,7 +3918,7 @@ func TestTag_Update_AutoCommit(t *testing.T) {
 	if g, w := execRequest.RequestOptions.RequestTag, "tag_1"; g != w {
 		t.Fatalf("statement tag mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3961,9 +3961,9 @@ func TestTag_AutoCommit_BatchDml(t *testing.T) {
 	_, _ = conn.ExecContext(ctx, testutil.UpdateBarSetFoo)
 	_, _ = conn.ExecContext(ctx, "run batch")
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// The ExecuteBatchDmlRequest and CommitRequest should have a transaction tag.
-	execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(execRequests), 1; g != w {
 		t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -3974,7 +3974,7 @@ func TestTag_AutoCommit_BatchDml(t *testing.T) {
 	if g, w := execRequest.RequestOptions.RequestTag, "tag_1"; g != w {
 		t.Fatalf("statement tag mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4037,9 +4037,9 @@ func TestTag_ReadWriteTransaction(t *testing.T) {
 	_, _ = tx.ExecContext(ctx, "run batch")
 	_ = tx.Commit()
 
-	requests := drainRequestsFromServer(server.TestSpanner)
+	requests := server.TestSpanner.DrainRequestsFromServer()
 	// The ExecuteSqlRequest and CommitRequest should have a transaction tag.
-	execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execRequests), 2; g != w {
 		t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4053,7 +4053,7 @@ func TestTag_ReadWriteTransaction(t *testing.T) {
 		}
 	}
 
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 	if g, w := len(batchRequests), 1; g != w {
 		t.Fatalf("number of batch request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4065,7 +4065,7 @@ func TestTag_ReadWriteTransaction(t *testing.T) {
 		t.Fatalf("statement tag mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4146,9 +4146,9 @@ func TestTag_ReadWriteTransaction_Retry(t *testing.T) {
 		})
 		_ = tx.Commit()
 
-		requests := drainRequestsFromServer(server.TestSpanner)
+		requests := server.TestSpanner.DrainRequestsFromServer()
 		// The ExecuteSqlRequest and CommitRequest should have a transaction tag.
-		execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(execRequests), 4; g != w {
 			t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4162,7 +4162,7 @@ func TestTag_ReadWriteTransaction_Retry(t *testing.T) {
 			}
 		}
 
-		batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+		batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchRequests), 2; g != w {
 			t.Fatalf("number of batch request mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4176,7 +4176,7 @@ func TestTag_ReadWriteTransaction_Retry(t *testing.T) {
 			}
 		}
 
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 		if g, w := len(commitRequests), 2; g != w {
 			t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4258,9 +4258,9 @@ func TestTag_RunTransaction_Retry(t *testing.T) {
 			t.Fatalf("failed to run transaction: %v", err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
+		requests := server.TestSpanner.DrainRequestsFromServer()
 		// The ExecuteSqlRequest and CommitRequest should have a transaction tag.
-		execRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		execRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(execRequests), 4; g != w {
 			t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4274,7 +4274,7 @@ func TestTag_RunTransaction_Retry(t *testing.T) {
 			}
 		}
 
-		batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
+		batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteBatchDmlRequest{}))
 		if g, w := len(batchRequests), 2; g != w {
 			t.Fatalf("number of batch request mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4288,7 +4288,7 @@ func TestTag_RunTransaction_Retry(t *testing.T) {
 			}
 		}
 
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 		if g, w := len(commitRequests), 2; g != w {
 			t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -4328,8 +4328,8 @@ func TestTag_RunTransactionWithOptions_IsNotSticky(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4349,8 +4349,8 @@ func TestTag_RunTransactionWithOptions_IsNotSticky(t *testing.T) {
 	if err := tx.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	requests = drainRequestsFromServer(server.TestSpanner)
-	commitRequests = requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	commitRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("number of commit request mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4377,8 +4377,8 @@ func TestMaxIdleConnectionsNonZero(t *testing.T) {
 
 	// Verify that only one client was created.
 	// This happens because we have a non-zero value for the number of idle connections.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	if g, w := len(batchRequests), 1; g != w {
 		t.Fatalf("BatchCreateSessions requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4400,8 +4400,8 @@ func TestMaxIdleConnectionsZero(t *testing.T) {
 
 	// Verify that two clients were created and closed.
 	// This should happen because we do not keep any idle connections open.
-	requests := drainRequestsFromServer(server.TestSpanner)
-	batchRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	batchRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BatchCreateSessionsRequest{}))
 	if g, w := len(batchRequests), 2; g != w {
 		t.Fatalf("BatchCreateSessions requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -4543,8 +4543,8 @@ func TestRunTransaction(t *testing.T) {
 		t.Fatal("internal retries should be enabled after RunTransaction")
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4555,7 +4555,7 @@ func TestRunTransaction(t *testing.T) {
 	if req.Transaction.GetBegin() == nil {
 		t.Fatalf("missing begin selector for ExecuteSqlRequest")
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4609,13 +4609,13 @@ func TestRunTransactionCommitAborted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	// There should be two requests, as the transaction is aborted and retried.
 	if g, w := len(sqlRequests), 2; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 2; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4689,13 +4689,13 @@ func TestRunTransactionQueryAborted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	// There should be two ExecuteSql requests, as the transaction is aborted and retried.
 	if g, w := len(sqlRequests), 2; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	// There should be only 1 CommitRequest, as the transaction is aborted before
 	// the first commit attempt.
 	if g, w := len(commitRequests), 1; g != w {
@@ -4760,12 +4760,12 @@ func TestRunTransactionQueryError(t *testing.T) {
 		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	// There should be no CommitRequest, as the transaction failed
 	if g, w := len(commitRequests), 0; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
@@ -4773,7 +4773,7 @@ func TestRunTransactionQueryError(t *testing.T) {
 	// There is no RollbackRequest, as the transaction was never started.
 	// The ExecuteSqlRequest included a BeginTransaction option, but because that
 	// request failed, the transaction was not started.
-	rollbackRequests := requestsOfType(requests, reflect.TypeOf(&sppb.RollbackRequest{}))
+	rollbackRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.RollbackRequest{}))
 	if g, w := len(rollbackRequests), 0; g != w {
 		t.Fatalf("rollback requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4827,12 +4827,12 @@ func TestRunTransactionCommitError(t *testing.T) {
 		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	// There should be no CommitRequest, as the transaction failed
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
@@ -4842,7 +4842,7 @@ func TestRunTransactionCommitError(t *testing.T) {
 	// a RollbackRequest if a Commit fails.
 	// TODO: Revisit once the client library has been checked whether it is really
 	//       necessary to send a Rollback after a failed Commit.
-	rollbackRequests := requestsOfType(requests, reflect.TypeOf(&sppb.RollbackRequest{}))
+	rollbackRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.RollbackRequest{}))
 	if g, w := len(rollbackRequests), 1; g != w {
 		t.Fatalf("rollback requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4913,8 +4913,8 @@ func TestTransactionWithLevelDisableRetryAborts(t *testing.T) {
 		t.Fatalf("error code mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -4925,7 +4925,7 @@ func TestTransactionWithLevelDisableRetryAborts(t *testing.T) {
 	if req.Transaction.GetBegin() == nil {
 		t.Fatalf("missing begin selector for ExecuteSqlRequest")
 	}
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 1; g != w {
 		t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -5003,8 +5003,8 @@ func TestBeginReadWriteTransaction(t *testing.T) {
 			t.Fatal("internal retries should still be enabled")
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(sqlRequests), 1; g != w {
 			t.Fatalf("ExecuteSqlRequests count mismatch\nGot: %v\nWant: %v", g, w)
 		}
@@ -5018,7 +5018,7 @@ func TestBeginReadWriteTransaction(t *testing.T) {
 		if g, w := req.RequestOptions.TransactionTag, tag; g != w {
 			t.Fatalf("transaction tag mismatch\n Got: %v\nWant: %v", g, w)
 		}
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 		if g, w := len(commitRequests), 1; g != w {
 			t.Fatalf("commit requests count mismatch\nGot: %v\nWant: %v", g, w)
 		}
@@ -5074,8 +5074,8 @@ func TestCustomClientConfig(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\nGot: %v\nWant: %v", g, w)
 	}
@@ -5134,8 +5134,8 @@ func TestPostgreSQLDialect(t *testing.T) {
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
 	}
-	requests := drainRequestsFromServer(server.TestSpanner)
-	sqlRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	sqlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(sqlRequests), 1; g != w {
 		t.Fatalf("sql requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -5565,30 +5565,6 @@ func filterBeginReadOnlyRequests(requests []interface{}) []*sppb.BeginTransactio
 		}
 	}
 	return res
-}
-
-func requestsOfType(requests []interface{}, t reflect.Type) []interface{} {
-	res := make([]interface{}, 0)
-	for _, req := range requests {
-		if reflect.TypeOf(req) == t {
-			res = append(res, req)
-		}
-	}
-	return res
-}
-
-func drainRequestsFromServer(server testutil.InMemSpannerServer) []interface{} {
-	var reqs []interface{}
-loop:
-	for {
-		select {
-		case req := <-server.ReceivedRequests():
-			reqs = append(reqs, req)
-		default:
-			break loop
-		}
-	}
-	return reqs
 }
 
 func waitFor(t *testing.T, assert func() error) {

--- a/partitioned_query_test.go
+++ b/partitioned_query_test.go
@@ -57,8 +57,8 @@ func TestBeginBatchReadOnlyTransaction(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		requests := drainRequestsFromServer(server.TestSpanner)
-		beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+		requests := server.TestSpanner.DrainRequestsFromServer()
+		beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 		if g, w := len(beginRequests), 1; g != w {
 			t.Fatalf("num begin requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -66,12 +66,12 @@ func TestBeginBatchReadOnlyTransaction(t *testing.T) {
 		if !beginRequest.Options.GetReadOnly().GetStrong() {
 			t.Fatal("missing strong timestamp bound option")
 		}
-		executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+		executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 		if g, w := len(executeRequests), 1; g != w {
 			t.Fatalf("num execute requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
 		// (Batch) read-only transactions should not be committed.
-		commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+		commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 		if g, w := len(commitRequests), 0; g != w {
 			t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 		}
@@ -152,8 +152,8 @@ func TestPartitionQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 	if g, w := len(beginRequests), 1; g != w {
 		t.Fatalf("num begin requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -161,11 +161,11 @@ func TestPartitionQuery(t *testing.T) {
 	if !beginRequest.Options.GetReadOnly().GetStrong() {
 		t.Fatal("missing strong timestamp bound option")
 	}
-	partitionRequests := requestsOfType(requests, reflect.TypeOf(&sppb.PartitionQueryRequest{}))
+	partitionRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.PartitionQueryRequest{}))
 	if g, w := len(partitionRequests), 1; g != w {
 		t.Fatalf("num partition requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
-	executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), len(pq.Partitions); g != w {
 		t.Fatalf("num execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -174,7 +174,7 @@ func TestPartitionQuery(t *testing.T) {
 		t.Fatal("missing DataBoostEnabled option")
 	}
 	// (Batch) read-only transactions should not be committed.
-	commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitRequests), 0; g != w {
 		t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 	}
@@ -303,8 +303,8 @@ func TestAutoPartitionQuery(t *testing.T) {
 				}
 			}
 
-			requests := drainRequestsFromServer(server.TestSpanner)
-			beginRequests := requestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
+			requests := server.TestSpanner.DrainRequestsFromServer()
+			beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.BeginTransactionRequest{}))
 			if g, w := len(beginRequests), 1; g != w {
 				t.Fatalf("num begin requests mismatch\n Got: %v\nWant: %v", g, w)
 			}
@@ -312,11 +312,11 @@ func TestAutoPartitionQuery(t *testing.T) {
 			if !beginRequest.Options.GetReadOnly().GetStrong() {
 				t.Fatal("missing strong timestamp bound option")
 			}
-			partitionRequests := requestsOfType(requests, reflect.TypeOf(&sppb.PartitionQueryRequest{}))
+			partitionRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.PartitionQueryRequest{}))
 			if g, w := len(partitionRequests), 1; g != w {
 				t.Fatalf("num partition requests mismatch\n Got: %v\nWant: %v", g, w)
 			}
-			executeRequests := requestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
+			executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 			if g, w := len(executeRequests), maxPartitions; g != w {
 				t.Fatalf("num execute requests mismatch\n Got: %v\nWant: %v", g, w)
 			}
@@ -325,7 +325,7 @@ func TestAutoPartitionQuery(t *testing.T) {
 				t.Fatal("missing DataBoostEnabled option")
 			}
 			// (Batch) read-only transactions should not be committed.
-			commitRequests := requestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
+			commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&sppb.CommitRequest{}))
 			if g, w := len(commitRequests), 0; g != w {
 				t.Fatalf("num commit requests mismatch\n Got: %v\nWant: %v", g, w)
 			}

--- a/stmt_with_mockserver_test.go
+++ b/stmt_with_mockserver_test.go
@@ -163,8 +163,8 @@ func TestPrepareWithValuerScanner(t *testing.T) {
 		t.Fatalf("failed to close rows: %v", err)
 	}
 
-	requests := drainRequestsFromServer(server.TestSpanner)
-	executeRequests := requestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
 	if g, w := len(executeRequests), 1; g != w {
 		t.Fatalf("number of execute requests mismatch\n Got: %v\nWant: %v", g, w)
 	}


### PR DESCRIPTION
Move a couple of test utility functions to the testutil package, so these can be used from any subpackage as well.