### PR TITLE
chore: add WriteMutations function for SpannerLib

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -683,6 +683,27 @@ func sum(affected []int64) int64 {
 	return sum
 }
 
+// WriteMutations is not part of the public API of the database/sql driver.
+// It is exported for internal reasons, and may receive breaking changes without prior notice.
+//
+// WriteMutations writes mutations using this connection. The mutations are either buffered in the current transaction,
+// or written directly to Spanner using a new read/write transaction if the connection does not have a transaction.
+//
+// The function returns an error if the connection currently has a read-only transaction.
+//
+// The returned CommitResponse is nil if the connection currently has a transaction, as the mutations will only be
+// applied to Spanner when the transaction commits.
+func (c *conn) WriteMutations(ctx context.Context, ms []*spanner.Mutation) (*spanner.CommitResponse, error) {
+	if c.inTransaction() {
+		return nil, c.BufferWrite(ms)
+	}
+	ts, err := c.Apply(ctx, ms)
+	if err != nil {
+		return nil, err
+	}
+	return &spanner.CommitResponse{CommitTs: ts}, nil
+}
+
 func (c *conn) Apply(ctx context.Context, ms []*spanner.Mutation, opts ...spanner.ApplyOption) (commitTimestamp time.Time, err error) {
 	if c.inTransaction() {
 		return time.Time{}, spanner.ToSpannerError(

--- a/spannerlib/api/connection_test.go
+++ b/spannerlib/api/connection_test.go
@@ -24,6 +24,7 @@ import (
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/go-sql-spanner/testutil"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestCreateAndCloseConnection(t *testing.T) {
@@ -139,6 +140,162 @@ func TestCloseConnectionTwice(t *testing.T) {
 			t.Fatalf("CloseConnection returned unexpected error: %v", err)
 		}
 	}
+	if err := ClosePool(ctx, poolId); err != nil {
+		t.Fatalf("ClosePool returned unexpected error: %v", err)
+	}
+}
+
+func TestWriteMutations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+
+	poolId, err := CreatePool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("CreatePool returned unexpected error: %v", err)
+	}
+	connId, err := CreateConnection(ctx, poolId)
+	if err != nil {
+		t.Fatalf("CreateConnection returned unexpected error: %v", err)
+	}
+
+	mutations := &spannerpb.BatchWriteRequest_MutationGroup{Mutations: []*spannerpb.Mutation{
+		{Operation: &spannerpb.Mutation_Insert{Insert: &spannerpb.Mutation_Write{
+			Table:   "my_table",
+			Columns: []string{"id", "value"},
+			Values: []*structpb.ListValue{
+				{Values: []*structpb.Value{structpb.NewStringValue("1"), structpb.NewStringValue("One")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("2"), structpb.NewStringValue("Two")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("3"), structpb.NewStringValue("Three")}},
+			},
+		}}},
+		{Operation: &spannerpb.Mutation_Update{Update: &spannerpb.Mutation_Write{
+			Table:   "my_table",
+			Columns: []string{"id", "value"},
+			Values: []*structpb.ListValue{
+				{Values: []*structpb.Value{structpb.NewStringValue("0"), structpb.NewStringValue("Zero")}},
+			},
+		}}},
+	}}
+	resp, err := WriteMutations(ctx, poolId, connId, mutations)
+	if err != nil {
+		t.Fatalf("WriteMutations returned unexpected error: %v", err)
+	}
+	if resp.CommitTimestamp == nil {
+		t.Fatalf("CommitTimestamp is nil")
+	}
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 1; g != w {
+		t.Fatalf("num BeginTransaction requests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+	if g, w := len(commitRequests), 1; g != w {
+		t.Fatalf("num CommitRequests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequest := commitRequests[0].(*spannerpb.CommitRequest)
+	if g, w := len(commitRequest.Mutations), 2; g != w {
+		t.Fatalf("num mutations mismatch\n Got: %d\nWant: %d", g, w)
+	}
+
+	// Write the same mutations in a transaction.
+	if err := BeginTransaction(ctx, poolId, connId, &spannerpb.TransactionOptions{}); err != nil {
+		t.Fatalf("BeginTransaction returned unexpected error: %v", err)
+	}
+	resp, err = WriteMutations(ctx, poolId, connId, mutations)
+	if err != nil {
+		t.Fatalf("WriteMutations returned unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("WriteMutations returned unexpected response: %v", resp)
+	}
+	resp, err = Commit(ctx, poolId, connId)
+	if err != nil {
+		t.Fatalf("Commit returned unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("Commit returned nil response")
+	}
+	if resp.CommitTimestamp == nil {
+		t.Fatalf("CommitTimestamp is nil")
+	}
+	requests = server.TestSpanner.DrainRequestsFromServer()
+	beginRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 1; g != w {
+		t.Fatalf("num BeginTransaction requests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequests = testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+	if g, w := len(commitRequests), 1; g != w {
+		t.Fatalf("num CommitRequests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequest = commitRequests[0].(*spannerpb.CommitRequest)
+	if g, w := len(commitRequest.Mutations), 2; g != w {
+		t.Fatalf("num mutations mismatch\n Got: %d\nWant: %d", g, w)
+	}
+
+	if err := ClosePool(ctx, poolId); err != nil {
+		t.Fatalf("ClosePool returned unexpected error: %v", err)
+	}
+}
+
+func TestWriteMutationsInReadOnlyTx(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+
+	poolId, err := CreatePool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("CreatePool returned unexpected error: %v", err)
+	}
+	connId, err := CreateConnection(ctx, poolId)
+	if err != nil {
+		t.Fatalf("CreateConnection returned unexpected error: %v", err)
+	}
+
+	// Start a read-only transaction and try to write mutations to that transaction. That should return an error.
+	if err := BeginTransaction(ctx, poolId, connId, &spannerpb.TransactionOptions{
+		Mode: &spannerpb.TransactionOptions_ReadOnly_{ReadOnly: &spannerpb.TransactionOptions_ReadOnly{}},
+	}); err != nil {
+		t.Fatalf("BeginTransaction returned unexpected error: %v", err)
+	}
+
+	mutations := &spannerpb.BatchWriteRequest_MutationGroup{Mutations: []*spannerpb.Mutation{
+		{Operation: &spannerpb.Mutation_Insert{Insert: &spannerpb.Mutation_Write{
+			Table:   "my_table",
+			Columns: []string{"id", "value"},
+			Values: []*structpb.ListValue{
+				{Values: []*structpb.Value{structpb.NewStringValue("1"), structpb.NewStringValue("One")}},
+			},
+		}}},
+	}}
+	_, err = WriteMutations(ctx, poolId, connId, mutations)
+	if g, w := spanner.ErrCode(err), codes.FailedPrecondition; g != w {
+		t.Fatalf("WriteMutations error code mismatch\n Got: %d\nWant: %d", g, w)
+	}
+
+	// Committing the read-only transaction should not lead to any commits on Spanner.
+	_, err = Commit(ctx, poolId, connId)
+	if err != nil {
+		t.Fatalf("Commit returned unexpected error: %v", err)
+	}
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	// There should also not be any BeginTransaction requests on Spanner, as the transaction was never really started
+	// by a query or other statement.
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 0; g != w {
+		t.Fatalf("num BeginTransaction requests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+	if g, w := len(commitRequests), 0; g != w {
+		t.Fatalf("num CommitRequests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+
 	if err := ClosePool(ctx, poolId); err != nil {
 		t.Fatalf("ClosePool returned unexpected error: %v", err)
 	}

--- a/spannerlib/lib/connection_test.go
+++ b/spannerlib/lib/connection_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/go-sql-spanner/testutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestCreateAndCloseConnection(t *testing.T) {
@@ -251,6 +252,65 @@ func TestBeginAndRollback(t *testing.T) {
 	}
 	if g, w := rollbackMsg.Length(), int32(0); g != w {
 		t.Fatalf("Rollback length mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	closeMsg := CloseConnection(ctx, poolMsg.ObjectId, connMsg.ObjectId)
+	if g, w := closeMsg.Code, int32(0); g != w {
+		t.Fatalf("CloseConnection result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	closeMsg = ClosePool(ctx, poolMsg.ObjectId)
+	if g, w := closeMsg.Code, int32(0); g != w {
+		t.Fatalf("ClosePool result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestWriteMutations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+
+	poolMsg := CreatePool(ctx, dsn)
+	if g, w := poolMsg.Code, int32(0); g != w {
+		t.Fatalf("CreatePool result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	connMsg := CreateConnection(ctx, poolMsg.ObjectId)
+	if g, w := connMsg.Code, int32(0); g != w {
+		t.Fatalf("CreateConnection result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	mutations := &spannerpb.BatchWriteRequest_MutationGroup{Mutations: []*spannerpb.Mutation{
+		{Operation: &spannerpb.Mutation_Insert{Insert: &spannerpb.Mutation_Write{
+			Table:   "my_table",
+			Columns: []string{"id", "value"},
+			Values: []*structpb.ListValue{
+				{Values: []*structpb.Value{structpb.NewStringValue("1"), structpb.NewStringValue("One")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("2"), structpb.NewStringValue("Two")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("3"), structpb.NewStringValue("Three")}},
+			},
+		}}},
+	}}
+	mutationBytes, err := proto.Marshal(mutations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutationsMsg := WriteMutations(ctx, poolMsg.ObjectId, connMsg.ObjectId, mutationBytes)
+	if g, w := mutationsMsg.Code, int32(0); g != w {
+		t.Fatalf("WriteMutations result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if mutationsMsg.Length() == 0 {
+		t.Fatal("WriteMutations returned no data")
+	}
+
+	// Write mutations in a transaction.
+	mutationsMsg = BeginTransaction(ctx, poolMsg.ObjectId, connMsg.ObjectId, mutationBytes)
+	// The response should now be an empty message, as the mutations were only buffered in the transaction.
+	if g, w := mutationsMsg.Code, int32(0); g != w {
+		t.Fatalf("WriteMutations result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if g, w := mutationsMsg.Length(), int32(0); g != w {
+		t.Fatalf("WriteMutations data length mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
 	closeMsg := CloseConnection(ctx, poolMsg.ObjectId, connMsg.ObjectId)

--- a/spannerlib/shared/shared_lib.go
+++ b/spannerlib/shared/shared_lib.go
@@ -111,6 +111,22 @@ func CloseConnection(poolId, connId int64) (int64, int32, int64, int32, unsafe.P
 	return pin(msg)
 }
 
+// WriteMutations writes an array of mutations to Spanner. The mutations are buffered in
+// the current read/write transaction if the connection currently has a read/write transaction.
+// The mutations are applied to the database in a new read/write transaction that is automatically
+// committed if the connection currently does not have a transaction.
+//
+// The function returns an error if the connection is currently in a read-only transaction.
+//
+// The mutationsBytes must be an encoded BatchWriteRequest_MutationGroup protobuf object.
+//
+//export WriteMutations
+func WriteMutations(poolId, connectionId int64, mutationsBytes []byte) (int64, int32, int64, int32, unsafe.Pointer) {
+	ctx := context.Background()
+	msg := lib.WriteMutations(ctx, poolId, connectionId, mutationsBytes)
+	return pin(msg)
+}
+
 // Execute executes a SQL statement on the given connection.
 // The return type is an identifier for a Rows object. This identifier can be used to
 // call the functions Metadata and Next to get respectively the metadata of the result

--- a/spannerlib/shared/shared_lib_test.go
+++ b/spannerlib/shared/shared_lib_test.go
@@ -412,6 +412,75 @@ func TestBeginAndRollbackTransaction(t *testing.T) {
 	}
 }
 
+func TestWriteMutations(t *testing.T) {
+	t.Parallel()
+
+	server, teardown := setupMockServer(t)
+	defer teardown()
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+
+	_, code, poolId, _, _ := CreatePool(dsn)
+	if g, w := code, int32(0); g != w {
+		t.Fatalf("CreatePool result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	_, code, connId, _, _ := CreateConnection(poolId)
+	if g, w := code, int32(0); g != w {
+		t.Fatalf("CreateConnection result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	mutations := &spannerpb.BatchWriteRequest_MutationGroup{Mutations: []*spannerpb.Mutation{
+		{Operation: &spannerpb.Mutation_Insert{Insert: &spannerpb.Mutation_Write{
+			Table:   "my_table",
+			Columns: []string{"id", "value"},
+			Values: []*structpb.ListValue{
+				{Values: []*structpb.Value{structpb.NewStringValue("1"), structpb.NewStringValue("One")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("2"), structpb.NewStringValue("Two")}},
+				{Values: []*structpb.Value{structpb.NewStringValue("3"), structpb.NewStringValue("Three")}},
+			},
+		}}},
+	}}
+	mutationBytes, err := proto.Marshal(mutations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// WriteMutations returns a CommitResponse or nil, depending on whether the connection has an active transaction.
+	mem, code, id, length, data := WriteMutations(poolId, connId, mutationBytes)
+	verifyDataMessage(t, "WriteMutations", mem, code, id, length, data)
+
+	response := &spannerpb.CommitResponse{}
+	responseBytes := reflect.SliceAt(reflect.TypeOf(byte(0)), data, int(length)).Bytes()
+	if err := proto.Unmarshal(responseBytes, response); err != nil {
+		t.Fatal(err)
+	}
+	if response.CommitTimestamp == nil {
+		t.Fatal("CommitTimestamp is nil")
+	}
+	// Release the memory held by the response.
+	if g, w := Release(mem), int32(0); g != w {
+		t.Fatalf("Release() result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	// Start a transaction on the connection and write the mutations to that transaction.
+	txOpts := &spannerpb.TransactionOptions{}
+	txOptsBytes, err := proto.Marshal(txOpts)
+	_, code, _, _, _ = BeginTransaction(poolId, connId, txOptsBytes)
+	if g, w := code, int32(0); g != w {
+		t.Fatalf("BeginTransaction result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	mem, code, id, length, data = WriteMutations(poolId, connId, mutationBytes)
+	// The response should now be an empty message, as the mutations were buffered in the current transaction.
+	verifyEmptyMessage(t, "WriteMutations in tx", mem, code, id, length, data)
+
+	_, code, _, _, _ = CloseConnection(poolId, connId)
+	if g, w := code, int32(0); g != w {
+		t.Fatalf("CloseConnection result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	_, code, _, _, _ = ClosePool(poolId)
+	if g, w := code, int32(0); g != w {
+		t.Fatalf("ClosePool result mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
 func verifyEmptyMessage(t *testing.T, name string, mem int64, code int32, id int64, length int32, res unsafe.Pointer) {
 	if g, w := mem, int64(0); g != w {
 		t.Fatalf("%s: mem ID mismatch\n Got: %v\nWant: %v", name, g, w)

--- a/spannerlib/wrappers/spannerlib-java/src/main/java/com/google/cloud/spannerlib/internal/SpannerLibrary.java
+++ b/spannerlib/wrappers/spannerlib-java/src/main/java/com/google/cloud/spannerlib/internal/SpannerLibrary.java
@@ -65,6 +65,15 @@ public interface SpannerLibrary extends Library {
   /** Closes the given Connection. */
   Message CloseConnection(long poolId, long connectionId);
 
+  /**
+   * Writes a group of mutations on Spanner. The mutations are buffered in the current read/write
+   * transaction if the connection has an active read/write transaction. Otherwise, the mutations
+   * are written directly to Spanner in a new read/write transaction. Returns a {@link
+   * com.google.spanner.v1.CommitResponse} if the mutations were written directly to Spanner, and an
+   * empty message if the mutations were only buffered in the current transaction.
+   */
+  Message WriteMutations(long poolId, long connectionId, GoBytes mutations);
+
   /** Starts a new transaction on the given Connection. */
   Message BeginTransaction(long poolId, long connectionId, GoBytes transactionOptions);
 

--- a/spannerlib/wrappers/spannerlib-java/src/test/java/com/google/cloud/spannerlib/ConnectionTest.java
+++ b/spannerlib/wrappers/spannerlib-java/src/test/java/com/google/cloud/spannerlib/ConnectionTest.java
@@ -18,10 +18,25 @@ package com.google.cloud.spannerlib;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import com.google.rpc.Code;
+import com.google.spanner.v1.BatchWriteRequest.MutationGroup;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.CreateSessionRequest;
+import com.google.spanner.v1.Mutation;
+import com.google.spanner.v1.Mutation.Write;
+import com.google.spanner.v1.TransactionOptions;
+import com.google.spanner.v1.TransactionOptions.ReadOnly;
 import org.junit.Test;
 
 public class ConnectionTest extends AbstractMockServerTest {
@@ -51,6 +66,140 @@ public class ConnectionTest extends AbstractMockServerTest {
         assertNotEquals(connection1.getId(), connection2.getId());
         assertEquals(1, mockSpanner.countRequestsOfType(CreateSessionRequest.class));
       }
+    }
+  }
+
+  @Test
+  public void testWriteMutations() {
+    String dsn =
+        String.format(
+            "localhost:%d/projects/p/instances/i/databases/d?usePlainText=true", getPort());
+    try (Pool pool = Pool.createPool(dsn);
+        Connection connection = pool.createConnection()) {
+      CommitResponse response =
+          connection.WriteMutations(
+              MutationGroup.newBuilder()
+                  .addMutations(
+                      Mutation.newBuilder()
+                          .setInsert(
+                              Write.newBuilder()
+                                  .addAllColumns(ImmutableList.of("id", "value"))
+                                  .addValues(
+                                      ListValue.newBuilder()
+                                          .addValues(Value.newBuilder().setStringValue("1").build())
+                                          .addValues(
+                                              Value.newBuilder().setStringValue("One").build())
+                                          .build())
+                                  .addValues(
+                                      ListValue.newBuilder()
+                                          .addValues(Value.newBuilder().setStringValue("2").build())
+                                          .addValues(
+                                              Value.newBuilder().setStringValue("Two").build())
+                                          .build())
+                                  .build())
+                          .build())
+                  .addMutations(
+                      Mutation.newBuilder()
+                          .setInsertOrUpdate(
+                              Write.newBuilder()
+                                  .addAllColumns(ImmutableList.of("id", "value"))
+                                  .addValues(
+                                      ListValue.newBuilder()
+                                          .addValues(Value.newBuilder().setStringValue("0").build())
+                                          .addValues(
+                                              Value.newBuilder().setStringValue("Zero").build())
+                                          .build())
+                                  .build())
+                          .build())
+                  .build());
+      assertNotNull(response);
+      assertNotNull(response.getCommitTimestamp());
+
+      assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      CommitRequest request = mockSpanner.getRequestsOfType(CommitRequest.class).get(0);
+      assertEquals(2, request.getMutationsCount());
+      assertEquals(2, request.getMutations(0).getInsert().getValuesCount());
+      assertEquals(1, request.getMutations(1).getInsertOrUpdate().getValuesCount());
+    }
+  }
+
+  @Test
+  public void testWriteMutationsInTransaction() {
+    String dsn =
+        String.format(
+            "localhost:%d/projects/p/instances/i/databases/d?usePlainText=true", getPort());
+    try (Pool pool = Pool.createPool(dsn);
+        Connection connection = pool.createConnection()) {
+      connection.beginTransaction(TransactionOptions.getDefaultInstance());
+      CommitResponse response =
+          connection.WriteMutations(
+              MutationGroup.newBuilder()
+                  .addMutations(
+                      Mutation.newBuilder()
+                          .setInsert(
+                              Write.newBuilder()
+                                  .addAllColumns(ImmutableList.of("id", "value"))
+                                  .addValues(
+                                      ListValue.newBuilder()
+                                          .addValues(Value.newBuilder().setStringValue("1").build())
+                                          .addValues(
+                                              Value.newBuilder().setStringValue("One").build())
+                                          .build())
+                                  .build())
+                          .build())
+                  .build());
+      // The mutations are only buffered in the current transaction, so there should be no response.
+      assertNull(response);
+
+      // Committing the transaction should return a CommitResponse.
+      response = connection.commit();
+      assertNotNull(response);
+      assertNotNull(response.getCommitTimestamp());
+
+      assertEquals(1, mockSpanner.countRequestsOfType(BeginTransactionRequest.class));
+      assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+      CommitRequest request = mockSpanner.getRequestsOfType(CommitRequest.class).get(0);
+      assertEquals(1, request.getMutationsCount());
+      assertEquals(1, request.getMutations(0).getInsert().getValuesCount());
+    }
+  }
+
+  @Test
+  public void testWriteMutationsInReadOnlyTransaction() {
+    String dsn =
+        String.format(
+            "localhost:%d/projects/p/instances/i/databases/d?usePlainText=true", getPort());
+    try (Pool pool = Pool.createPool(dsn);
+        Connection connection = pool.createConnection()) {
+      connection.beginTransaction(
+          TransactionOptions.newBuilder().setReadOnly(ReadOnly.newBuilder().build()).build());
+      SpannerLibException exception =
+          assertThrows(
+              SpannerLibException.class,
+              () ->
+                  connection.WriteMutations(
+                      MutationGroup.newBuilder()
+                          .addMutations(
+                              Mutation.newBuilder()
+                                  .setInsert(
+                                      Write.newBuilder()
+                                          .addAllColumns(ImmutableList.of("id", "value"))
+                                          .addValues(
+                                              ListValue.newBuilder()
+                                                  .addValues(
+                                                      Value.newBuilder()
+                                                          .setStringValue("1")
+                                                          .build())
+                                                  .addValues(
+                                                      Value.newBuilder()
+                                                          .setStringValue("One")
+                                                          .build())
+                                                  .build())
+                                          .build())
+                                  .build())
+                          .build()));
+      assertEquals(Code.FAILED_PRECONDITION.getNumber(), exception.getStatus().getCode());
     }
   }
 }


### PR DESCRIPTION
Adds a WriteMutations function for SpannerLib. This function can be used to write mutations to Spanner in two ways:
1. In a transaction: The mutations are buffered in the current read/write transaction. The returned message is empty.
2. Outside a transaction: The mutations are written to Spanner directly in a new read/write transaction. The returned message contains the CommitResponse.