### PR TITLE
chore: increase message size for gRPC server

### DIFF
--- a/spannerlib/grpc-server/server.go
+++ b/spannerlib/grpc-server/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"math"
 	"net"
 	"os"
 	"os/signal"
@@ -46,6 +47,8 @@ func main() {
 		log.Fatalf("failed to listen: %v\n", err)
 	}
 	var opts []grpc.ServerOption
+	// Set a max message size that is essentially no limit.
+	opts = append(opts, grpc.MaxRecvMsgSize(math.MaxInt32))
 	grpcServer := grpc.NewServer(opts...)
 
 	server := spannerLibServer{}


### PR DESCRIPTION
Increase the max message size for the internal gRPC server for SpannerLib. This allows clients to send messages of any size to the shared library when using gRPC.