### PR TITLE
fix: return batch update counts also when retries are disabled

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -744,7 +744,7 @@ func (tx *readWriteTransaction) runDmlBatch(ctx context.Context) (*result, error
 
 	if !tx.retryAborts() {
 		affected, err := tx.rwTx.BatchUpdateWithOptions(ctx, statements, options.QueryOptions)
-		return &result{rowsAffected: sum(affected)}, err
+		return &result{rowsAffected: sum(affected), batchUpdateCounts: affected}, err
 	}
 
 	var affected []int64


### PR DESCRIPTION
The RunDmlBatch function of SpannerConn returns a Spanner-specific result type that also contains the actual update counts per statement in a batch, and not only the total update count. This was however not correctly returned if a DML batch was executed in a read/write transaction with retries disabled.