### PR TITLE
chore: add WriteMutationsAsync to .NET wrapper

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
@@ -172,7 +172,25 @@ public class GrpcLibSpanner : ISpannerLib
         }));
         return response.CommitTimestamp == null ? null : response;
     }
-
+    
+    public async Task<CommitResponse?> WriteMutationsAsync(Connection connection,
+        BatchWriteRequest.Types.MutationGroup mutations, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _client.WriteMutationsAsync(new WriteMutationsRequest
+            {
+                Connection = ToProto(connection),
+                Mutations = mutations,
+            }, cancellationToken: cancellationToken);
+            return response.CommitTimestamp == null ? null : response;
+        }
+        catch (RpcException exception)
+        {
+            throw SpannerException.ToSpannerException(exception);
+        }
+    }
+    
     public Rows Execute(Connection connection, ExecuteSqlRequest statement)
     {
         if (_useStreamingRows) 

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native-impl/SharedLibSpanner.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native-impl/SharedLibSpanner.cs
@@ -104,6 +104,12 @@ public class SharedLibSpanner : ISpannerLib
         }
         return CommitResponse.Parser.ParseFrom(handler.Value());
     }
+    
+    public Task<CommitResponse?> WriteMutationsAsync(Connection connection,
+        BatchWriteRequest.Types.MutationGroup mutations, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => WriteMutations(connection, mutations), cancellationToken);
+    }
 
     public Rows Execute(Connection connection, ExecuteSqlRequest statement)
     {

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Connection.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Connection.cs
@@ -88,7 +88,25 @@ public class Connection(Pool pool, long id) : AbstractLibObject(pool.Spanner, id
     {
         return Spanner.WriteMutations(this, mutations);
     }
-
+    
+    /// <summary>
+    /// Writes the given list of mutations to Spanner. If the connection has an active read/write transaction, then the
+    /// mutations will be buffered in the current transaction and sent to Spanner when the transaction is committed.
+    /// If the connection does not have a transaction, then the mutations are sent to Spanner directly in a new
+    /// read/write transaction.
+    /// </summary>
+    /// <param name="mutations">The mutations to write to Spanner</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    /// The CommitResponse that is returned by Spanner, or null if the mutations were only buffered in the current
+    /// transaction.
+    /// </returns>
+    public Task<CommitResponse?> WriteMutationsAsync(BatchWriteRequest.Types.MutationGroup mutations,
+        CancellationToken cancellationToken = default)
+    {
+        return Spanner.WriteMutationsAsync(this, mutations, cancellationToken);
+    }
+    
     /// <summary>
     /// Executes any type of SQL statement on this connection. The SQL statement will use the current transaction of the
     /// connection. The contents of the returned Rows object depends on the type of SQL statement.

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/ISpannerLib.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/ISpannerLib.cs
@@ -92,6 +92,21 @@ public interface ISpannerLib : IDisposable
     public CommitResponse? WriteMutations(Connection connection, BatchWriteRequest.Types.MutationGroup mutations);
 
     /// <summary>
+    /// Writes an array of mutations to Spanner. The mutations are buffered in the current transaction of the given
+    /// connection (if any). Otherwise, the mutations are written directly to Spanner using a new read/write
+    /// transaction and the CommitResponse of that transaction is returned. The returned value is null if the mutations
+    /// were only buffered in an active transaction.
+    /// </summary>
+    /// <param name="connection">The connection to use to write the mutations</param>
+    /// <param name="mutations">The mutations to write</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    /// The CommitResponse of the read/write transaction that was created to write the mutations, or null if the
+    /// mutations were buffered in an active transaction on the connection.
+    /// </returns>
+    public Task<CommitResponse?> WriteMutationsAsync(Connection connection, BatchWriteRequest.Types.MutationGroup mutations, CancellationToken cancellationToken = default);
+    
+    /// <summary>
     /// Executes a SQL statement of any type on the given connection.
     /// </summary>
     /// <param name="connection">The connection to use to execute the SQL statement</param>


### PR DESCRIPTION
Add an async version of the WriteMutations method to the .NET wrapper.