### PR TITLE
feat: support connect_timeout property

### DIFF
--- a/connection_properties.go
+++ b/connection_properties.go
@@ -461,6 +461,15 @@ var propertyDisableStatementCache = createConnectionProperty(
 	connectionstate.ContextStartup,
 	connectionstate.ConvertBool,
 )
+var propertyConnectTimeout = createConnectionProperty(
+	"connect_timeout",
+	"The amount of time to wait before timing out when creating a new connection.",
+	0,
+	false,
+	nil,
+	connectionstate.ContextStartup,
+	connectionstate.ConvertDuration,
+)
 
 // Generated read-only properties. These cannot be set by the user anywhere.
 var propertyCommitTimestamp = createReadOnlyConnectionProperty(

--- a/connectionstate/converters.go
+++ b/connectionstate/converters.go
@@ -113,7 +113,7 @@ func parseTimestamp(re *regexp.Regexp, params string) (time.Time, error) {
 func parseDuration(re *regexp.Regexp, value string) (time.Duration, error) {
 	matches := matchesToMap(re, value)
 	if matches["duration"] == "" && matches["number"] == "" && matches["null"] == "" {
-		return 0, spanner.ToSpannerError(status.Error(codes.InvalidArgument, fmt.Sprintf("No duration found: %v", value)))
+		return 0, spanner.ToSpannerError(status.Error(codes.InvalidArgument, fmt.Sprintf("No or invalid duration found: %v", value)))
 	}
 	if matches["duration"] != "" {
 		d, err := time.ParseDuration(matches["duration"])

--- a/driver.go
+++ b/driver.go
@@ -732,6 +732,17 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 		c.connectorConfig.Project,
 		c.connectorConfig.Instance,
 		c.connectorConfig.Database)
+	if value, ok := c.initialPropertyValues[propertyConnectTimeout.Key()]; ok {
+		if timeout, err := value.GetValue(); err == nil {
+			if duration, ok := timeout.(time.Duration); ok {
+				var cancel context.CancelFunc
+				// This will set the actual timeout of the context to the lower of the
+				// current context timeout (if any) and the value from the connection property.
+				ctx, cancel = context.WithTimeout(ctx, duration)
+				defer cancel()
+			}
+		}
+	}
 
 	if err := c.increaseConnCount(ctx, databaseName, opts); err != nil {
 		return nil, err


### PR DESCRIPTION
Add support for a connect_timeout property that sets the maximum time that the driver will wait when creating a new connection to Spanner. This property only affects the very first creation of a connection to Spanner for a given connector. Once a connection has been established, all further connection creations will not use this value.

Fixes #576