### PR TITLE
feat: add support for statement-scoped connection state

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spannerdriver
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/googleapis/go-sql-spanner/connectionstate"
+	"github.com/googleapis/go-sql-spanner/parser"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestApplyStatementScopedValues(t *testing.T) {
+	t.Parallel()
+
+	c := &conn{
+		logger: noopLogger,
+		state:  createInitialConnectionState(connectionstate.TypeNonTransactional, map[string]connectionstate.ConnectionPropertyValue{}),
+	}
+	if g, w := propertyIsolationLevel.GetValueOrDefault(c.state), sql.LevelDefault; g != w {
+		t.Fatalf("default isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	// Add a statement-scoped connection property value for isolation_level.
+	cleanup, err := c.applyStatementScopedValues(&ExecOptions{
+		PropertyValues: []PropertyValue{
+			CreatePropertyValue("isolation_level", "repeatable read"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g, w := propertyIsolationLevel.GetValueOrDefault(c.state), sql.LevelRepeatableRead; g != w {
+		t.Fatalf("statement isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	// Clean up the statement-scoped connection properties.
+	cleanup()
+
+	// The isolation level should now be back to default.
+	if g, w := propertyIsolationLevel.GetValueOrDefault(c.state), sql.LevelDefault; g != w {
+		t.Fatalf("default isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestApplyStatementScopedValuesWithInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	c := &conn{
+		logger: noopLogger,
+		state:  createInitialConnectionState(connectionstate.TypeNonTransactional, map[string]connectionstate.ConnectionPropertyValue{}),
+	}
+
+	// Add a statement-scoped connection property value for isolation_level with an invalid value.
+	_, err := c.applyStatementScopedValues(&ExecOptions{
+		PropertyValues: []PropertyValue{
+			CreatePropertyValue("isolation_level", "not an isolation level"),
+		},
+	})
+	if g, w := status.Code(err), codes.InvalidArgument; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if g, w := propertyIsolationLevel.GetValueOrDefault(c.state), sql.LevelDefault; g != w {
+		t.Fatalf("statement isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestApplyStatementScopedValuesWithUnknownProperty(t *testing.T) {
+	t.Parallel()
+
+	c := &conn{
+		logger: noopLogger,
+		state:  createInitialConnectionState(connectionstate.TypeNonTransactional, map[string]connectionstate.ConnectionPropertyValue{}),
+	}
+
+	// Add a statement-scoped connection property value for an unknown property without an extension.
+	_, err := c.applyStatementScopedValues(&ExecOptions{
+		PropertyValues: []PropertyValue{
+			CreatePropertyValue("non_existing_property", "some-value"),
+		},
+	})
+	if g, w := status.Code(err), codes.InvalidArgument; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if g, w := propertyIsolationLevel.GetValueOrDefault(c.state), sql.LevelDefault; g != w {
+		t.Fatalf("statement isolation level mismatch\n Got: %v\nWant: %v", g, w)
+	}
+}
+
+func TestApplyStatementScopedValuesWithExtension(t *testing.T) {
+	t.Parallel()
+
+	c := &conn{
+		logger: noopLogger,
+		state:  createInitialConnectionState(connectionstate.TypeNonTransactional, map[string]connectionstate.ConnectionPropertyValue{}),
+	}
+
+	// Add a statement-scoped connection property value for an unknown property with an extension.
+	// Property values for unknown properties with an extension are allowed.
+	propValue := PropertyValue{
+		Identifier: parser.Identifier{Parts: []string{"my_extension", "my_property"}},
+		Value:      "some-value",
+	}
+	cleanup, err := c.applyStatementScopedValues(&ExecOptions{
+		PropertyValues: []PropertyValue{propValue},
+	})
+	if g, w := status.Code(err), codes.OK; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	val, ok, err := c.state.GetValue("my_extension", "my_property")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("missing my_extension.my_property")
+	}
+	if g, w := val, "some-value"; g != w {
+		t.Fatalf("value mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	cleanup()
+
+	// The value should now be gone.
+	_, ok, err = c.state.GetValue("my_extension", "my_property")
+	if g, w := status.Code(err), codes.InvalidArgument; g != w {
+		t.Fatalf("error mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if ok {
+		t.Fatal("got unexpected value for my_extension.my_property")
+	}
+}

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -23,9 +23,26 @@ import (
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/go-sql-spanner/connectionstate"
+	"github.com/googleapis/go-sql-spanner/parser"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// PropertyValue is an untyped property value for a connection property.
+// These can be set on an ExecOptions instance to set statement-scoped connection property values for a
+// single statement execution.
+type PropertyValue struct {
+	Identifier parser.Identifier
+	Value      string
+}
+
+// CreatePropertyValue creates an untyped property value for a connection variable.
+func CreatePropertyValue(name, value string) PropertyValue {
+	return PropertyValue{
+		Identifier: parser.Identifier{Parts: []string{name}},
+		Value:      value,
+	}
+}
 
 // connectionProperties contains all supported connection properties for Spanner.
 // These properties are added to all connectionstate.ConnectionState instances that are created for Spanner connections.

--- a/driver.go
+++ b/driver.go
@@ -214,6 +214,11 @@ type ExecOptions struct {
 	// DirectExecuteContext is the context that is used for the execution of a query
 	// when DirectExecuteQuery is enabled.
 	DirectExecuteContext context.Context
+
+	// PropertyValues contains a list of connection state property values that
+	// should be used while executing the statement. These values will only be used for
+	// this statement, and will not be persisted on the connection.
+	PropertyValues []PropertyValue
 }
 
 func (dest *ExecOptions) merge(src *ExecOptions) {
@@ -240,6 +245,9 @@ func (dest *ExecOptions) merge(src *ExecOptions) {
 	}
 	if src.AutocommitDMLMode != Unspecified {
 		dest.AutocommitDMLMode = src.AutocommitDMLMode
+	}
+	if src.PropertyValues != nil {
+		dest.PropertyValues = append(dest.PropertyValues, src.PropertyValues...)
 	}
 	(&dest.PartitionedQueryOptions).merge(&src.PartitionedQueryOptions)
 	mergeQueryOptions(&dest.QueryOptions, &src.QueryOptions)

--- a/statements.go
+++ b/statements.go
@@ -130,7 +130,7 @@ func (s *executableSetStatement) execute(c *conn) error {
 		return status.Errorf(codes.InvalidArgument, "statement contains %d identifiers, but %d values given", len(s.stmt.Identifiers), len(s.stmt.Literals))
 	}
 	for index := range s.stmt.Identifiers {
-		if err := c.setConnectionVariable(s.stmt.Identifiers[index], s.stmt.Literals[index].Value, s.stmt.IsLocal, s.stmt.IsTransaction); err != nil {
+		if err := c.setConnectionVariable(s.stmt.Identifiers[index], s.stmt.Literals[index].Value, s.stmt.IsLocal, s.stmt.IsTransaction /*statementScoped=*/, false); err != nil {
 			return err
 		}
 	}
@@ -143,14 +143,14 @@ type executableResetStatement struct {
 }
 
 func (s *executableResetStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
-	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false); err != nil {
+	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false, false); err != nil {
 		return nil, err
 	}
 	return driver.ResultNoRows, nil
 }
 
 func (s *executableResetStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false); err != nil {
+	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false, false); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -291,7 +291,7 @@ func (s *executableBeginStatement) execContext(ctx context.Context, c *conn, opt
 		return nil, err
 	}
 	for index := range s.stmt.Identifiers {
-		if err := c.setConnectionVariable(s.stmt.Identifiers[index], s.stmt.Literals[index].Value /*IsLocal=*/, true /*IsTransaction=*/, true); err != nil {
+		if err := c.setConnectionVariable(s.stmt.Identifiers[index], s.stmt.Literals[index].Value /*IsLocal=*/, true /*IsTransaction=*/, true /*statementScoped=*/, false); err != nil {
 			return nil, err
 		}
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -80,6 +80,10 @@ func (s *stmt) CheckNamedValue(value *driver.NamedValue) error {
 		s.execOptions = &execOptions
 		return driver.ErrRemoveArgument
 	}
+	if execOptions, ok := value.Value.(*ExecOptions); ok {
+		s.execOptions = execOptions
+		return driver.ErrRemoveArgument
+	}
 	return s.conn.CheckNamedValue(value)
 }
 


### PR DESCRIPTION
Add support for statement-scoped connection state. Statement-scoped values are only
valid for the duration of the execution of a single statement. These values can be
set in ExecOptions and used as an argument for QueryContext and ExecContext.

A separate pull request will be added later that enables the use of statement-scoped
connection variables in statement hints. That is, the following statement will apply
the hints that correspond with valid connection properties as statement-scoped
properties for the statement:

```sql
@{rpc_priority=high, statement_tag='my_tag'} select * from my_table
```