### PR TITLE
fix: dollar-quote tags may not contain whitespaces

### DIFF
--- a/parser/simple_parser.go
+++ b/parser/simple_parser.go
@@ -138,7 +138,7 @@ func (p *simpleParser) eatDollarTag() (string, bool) {
 				return "", false
 			}
 		} else {
-			if p.eatToken('$') {
+			if p.eatTokenWithWhitespaceOption('$' /*eatWhiteSpaces=*/, false) {
 				return string(p.sql[startPos : p.pos-1]), true
 			}
 			if !p.isValidIdentifierChar() {
@@ -393,12 +393,18 @@ func (p *simpleParser) skipStatementHint() bool {
 // isMultibyte returns true if the character at the current position
 // is a multibyte utf8 character.
 func (p *simpleParser) isMultibyte() bool {
+	if p.pos >= len(p.sql) {
+		return false
+	}
 	return isMultibyte(p.sql[p.pos])
 }
 
 // nextChar moves the parser to the next character. This takes into
 // account that some characters could be multibyte characters.
 func (p *simpleParser) nextChar() {
+	if p.pos >= len(p.sql) {
+		return
+	}
 	if !p.isMultibyte() {
 		p.pos++
 		return

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -1140,6 +1140,11 @@ SELECT * FROM PersonsTable WHERE id=$1`,
 			wantSQL: `select foo from bar where id=$tag$this is a string$tag$ and value=$1 order by value`,
 			want:    []string{"p1"},
 		},
+		"dollar-quoted string with tag with unicode chars": {
+			input:   `SELECT $ÿabc0$literal string ? ?$ÿabc0 $ÿabc0$`,
+			wantSQL: `SELECT $ÿabc0$literal string ? ?$ÿabc0 $ÿabc0$`,
+			want:    []string{},
+		},
 		"invalid dollar-quoted string": {
 			input: "select foo from bar where id=$tag$this is an invalid string and value=? order by value",
 			wantErr: spanner.ToSpannerError(
@@ -1227,6 +1232,16 @@ func TestFindParamsWithCommentsPostgreSQL(t *testing.T) {
 		"dollar-quoted string with tag": {
 			input:   `?$tag$?it$?s$tag$%s?`,
 			wantSQL: `$1$tag$?it$?s$tag$%s$2`,
+			want:    []string{"p1", "p2"},
+		},
+		"dollar-quoted string with tag similar tag inside": {
+			input:   `$tag$ $tag $tag$`,
+			wantSQL: `$tag$ $tag $tag$`,
+			want:    []string{},
+		},
+		"dollar-quoted string with nested dollar-quoted string": {
+			input:   ` ? $tag$ $tag2$ test ? $tag2$ $tag$ ? `,
+			wantSQL: ` $1 $tag$ $tag2$ test ? $tag2$ $tag$ $2 `,
 			want:    []string{"p1", "p2"},
 		},
 		"dollar-quoted string with linefeed": {
@@ -2267,6 +2282,26 @@ func TestEatDollarQuotedString(t *testing.T) {
 			input:   "$outer$ outer string $inner$ mismatched tag $outer$ second part of outer string $inner$",
 			want:    "",
 			wantErr: true,
+		},
+		{
+			input:   "$outer$ outer string $outer $outer$",
+			want:    " outer string $outer ",
+			wantErr: false,
+		},
+		{
+			input:   "$tag$value $tag#$tag$",
+			want:    "value $tag#",
+			wantErr: false,
+		},
+		{
+			input:   "$tag$value $tag--not a comment$tag$",
+			want:    "value $tag--not a comment",
+			wantErr: false,
+		},
+		{
+			input:   "$tag$value $tag/*not a comment*/$tag$",
+			want:    "value $tag/*not a comment*/",
+			wantErr: false,
 		},
 	}
 	statementParser, err := NewStatementParser(databasepb.DatabaseDialect_POSTGRESQL, 1000)


### PR DESCRIPTION
Whitespaces inside dollar-quote tags are not allowed. Tags for dollar-quoted strings follow the rules for unquoted identifiers in PostgreSQL.

See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING