### PR TITLE
chore: fix error message when adding a query in a batch

### DIFF
--- a/spannerlib/api/connection.go
+++ b/spannerlib/api/connection.go
@@ -480,7 +480,7 @@ func determineBatchType(conn *Connection, statements []*spannerpb.ExecuteBatchDm
 		} else if firstStatementType == parser.StatementTypeDdl {
 			batchType = parser.BatchTypeDdl
 		} else {
-			return status.Errorf(codes.InvalidArgument, "unsupported statement type for batching: %v", firstStatementType)
+			return status.Errorf(codes.InvalidArgument, "unsupported statement for batching: %v", statements[0].Sql)
 		}
 		for i, statement := range statements {
 			if i > 0 {


### PR DESCRIPTION
Adding a query to a batch would return a slightly cryptic error message in the form

```
unsupported statement type for batching: 1
```

The reason for that was that it showed the internal constant value for statement type, which for queries is '1'. The error message is now:

```
unsupported statement for batching: select foo from bar
```