### PR TITLE
chore: remove local nuget packages in dotnet build script

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/build.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/build.sh
@@ -38,8 +38,11 @@ echo "Skip windows: $SKIP_WINDOWS"
 
 # Remove existing builds
 rm -r ./spannerlib-dotnet-native/libraries 2> /dev/null
+rm -r ./spannerlib-dotnet-grpc-server/binaries 2> /dev/null
 rm -r ./*/bin 2> /dev/null
 rm -r ./*/obj 2> /dev/null
+# Remove all local nuget packages to force the use of the new ones that will be built in this script.
+dotnet nuget locals global-packages --clear
 
 # Build gRPC server
 echo "Building gRPC server..."

--- a/spannerlib/wrappers/spannerlib-dotnet/publish.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/publish.sh
@@ -20,6 +20,9 @@ fi
 # Build all components
 ./build.sh
 
+# Remove existing packages to ensure that only the packages that are built in the next step will be pushed to nuget.
+find ./**/bin/Release -type f -name "Alpha*.nupkg" -exec rm {} \;
+
 # Pack and publish to nuget
 dotnet pack
 find ./**/bin/Release -type f -name "Alpha*.nupkg" -exec \


### PR DESCRIPTION
Remove locally cached nuget packages in the dotnet build and publish scripts. This ensures that only the newest packages are used and pushed to nuget.