### PR TITLE
chore: remove gRPC msg size limit

### DIFF
--- a/spannerlib/grpc-server/server.go
+++ b/spannerlib/grpc-server/server.go
@@ -46,6 +46,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v\n", err)
 	}
+	grpcServer, err := createServer()
+	if err != nil {
+		log.Fatalf("failed to create server: %v\n", err)
+	}
+	log.Printf("Starting gRPC server on %s\n", lis.Addr().String())
+	err = grpcServer.Serve(lis)
+	if err != nil {
+		log.Printf("failed to serve: %v\n", err)
+	}
+}
+
+func createServer() (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 	// Set a max message size that is essentially no limit.
 	opts = append(opts, grpc.MaxRecvMsgSize(math.MaxInt32))
@@ -53,11 +65,8 @@ func main() {
 
 	server := spannerLibServer{}
 	pb.RegisterSpannerLibServer(grpcServer, &server)
-	log.Printf("Starting gRPC server on %s\n", lis.Addr().String())
-	err = grpcServer.Serve(lis)
-	if err != nil {
-		log.Printf("failed to serve: %v\n", err)
-	}
+
+	return grpcServer, nil
 }
 
 var _ pb.SpannerLibServer = &spannerLibServer{}

--- a/testutil/mocked_inmem_server.go
+++ b/testutil/mocked_inmem_server.go
@@ -17,6 +17,7 @@ package testutil
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 	"testing"
@@ -111,7 +112,10 @@ func (s *MockedSpannerInMemTestServer) setupMockedServerWithAddr(t *testing.T, a
 	s.setupSelect1Result()
 	s.setupFooResults()
 	s.setupSingersResults()
-	s.server = grpc.NewServer()
+	var serverOpts []grpc.ServerOption
+	// Set a max message size that is essentially no limit.
+	serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(math.MaxInt32))
+	s.server = grpc.NewServer(serverOpts...)
 	spannerpb.RegisterSpannerServer(s.server, s.TestSpanner)
 	instancepb.RegisterInstanceAdminServer(s.server, s.TestInstanceAdmin)
 	databasepb.RegisterDatabaseAdminServer(s.server, s.TestDatabaseAdmin)


### PR DESCRIPTION
Remove the gRPC message size limit for the SpannerLib gRPC server.

Also remove the limit on the mock server that is used for Spanner to prevent test failures due to the large message test for the SpannerLib gRPC server.