### PR TITLE
chore: use QueryMode in Execute in SpannerLib

### DIFF
--- a/spannerlib/api/connection.go
+++ b/spannerlib/api/connection.go
@@ -445,6 +445,9 @@ func extractParams(directExecuteContext context.Context, statement *spannerpb.Ex
 		ReturnResultSetStats:    true,
 		DirectExecuteQuery:      true,
 		DirectExecuteContext:    directExecuteContext,
+		QueryOptions: spanner.QueryOptions{
+			Mode: &statement.QueryMode,
+		},
 	})
 	if statement.Params != nil {
 		if statement.ParamTypes == nil {


### PR DESCRIPTION
The QueryMode that was set on an ExecuteSqlRequest was not used by SpannerLib. QueryMode can be set to for example PLAN to only return the query plan and metadata of the statement. This is often used by drivers to return metadata of a statement to an application.