### PR TITLE
test: increase execution time to ensure that timeout is triggered

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -327,7 +327,7 @@ func TestTransactionTimeoutSecondStatement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 30 * time.Millisecond})
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 50 * time.Millisecond})
 	rows, err := tx.QueryContext(ctx, testutil.SelectFooFromBar, ExecOptions{DirectExecuteQuery: true})
 	if rows != nil {
 		_ = rows.Close()


### PR DESCRIPTION
Increase the simulated execution time to ensure that the timeout error is triggered.

Fixes #618