### PR TITLE
test: unflake TestNoLeak

### DIFF
--- a/aborted_transactions_test.go
+++ b/aborted_transactions_test.go
@@ -442,7 +442,7 @@ func testRetryReadWriteTransactionWithQuery(t *testing.T, setupServer func(serve
 	if setupServer != nil {
 		setupServer(server.TestSpanner)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Second)
 	defer cancel()
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -470,16 +470,16 @@ func testRetryReadWriteTransactionWithQuery(t *testing.T, setupServer func(serve
 	}
 	err = rows.Err()
 	if g, w := spanner.ErrCode(err), wantErrCode; g != w {
-		t.Fatalf("next error mismatch\nGot: %v\nWant: %v", g, w)
+		t.Fatalf("next error mismatch\n Got: %v\nWant: %v", g, w)
 	}
 	if wantErrCode == codes.OK {
 		if numRowsToConsume > -1 {
 			if g, w := len(values), firstNonZero(numRowsToConsume, 2); g != w {
-				t.Fatalf("row count mismatch\nGot: %v\nWant: %v", g, w)
+				t.Fatalf("row count mismatch\n Got: %v\nWant: %v", g, w)
 			}
 			wantValues := ([]int64{1, 2})[:firstNonZero(numRowsToConsume, 2)]
 			if !cmp.Equal(wantValues, values) {
-				t.Fatalf("values mismatch\nGot: %v\nWant: %v", values, wantValues)
+				t.Fatalf("values mismatch\n Got: %v\nWant: %v", values, wantValues)
 			}
 		}
 	}
@@ -492,16 +492,16 @@ func testRetryReadWriteTransactionWithQuery(t *testing.T, setupServer func(serve
 	}
 	err = tx.Commit()
 	if err != wantCommitErr {
-		t.Fatalf("commit error mismatch\nGot: %v\nWant: %v", err, wantCommitErr)
+		t.Fatalf("commit error mismatch\n Got: %v\nWant: %v", err, wantCommitErr)
 	}
 	reqs := server.TestSpanner.DrainRequestsFromServer()
 	execReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.ExecuteSqlRequest{}))
 	if g, w := len(execReqs), wantSqlExecuteCount; g != w {
-		t.Fatalf("execute request count mismatch\nGot: %v\nWant: %v", g, w)
+		t.Fatalf("execute request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
 	commitReqs := testutil.RequestsOfType(reqs, reflect.TypeOf(&sppb.CommitRequest{}))
 	if g, w := len(commitReqs), wantCommitCount; g != w {
-		t.Fatalf("commit request count mismatch\nGot: %v\nWant: %v", g, w)
+		t.Fatalf("commit request count mismatch\n Got: %v\nWant: %v", g, w)
 	}
 
 	// Execute another statement to ensure that the session that was used

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -160,7 +160,7 @@ func TestBeginTransactionReadOnly(t *testing.T) {
 	}
 	defer silentClose(conn)
 
-	if _, err := conn.ExecContext(ctx, "begin transaction read write"); err != nil {
+	if _, err := conn.ExecContext(ctx, "begin transaction read only"); err != nil {
 		t.Fatal(err)
 	}
 	row := conn.QueryRowContext(ctx, testutil.SelectFooFromBar, ExecOptions{DirectExecuteQuery: true})
@@ -183,11 +183,10 @@ func TestBeginTransactionReadOnly(t *testing.T) {
 	if request.GetTransaction() == nil || request.GetTransaction().GetBegin() == nil {
 		t.Fatal("missing begin transaction on ExecuteSqlRequest")
 	}
-	// TODO: Enable once transaction_read_only is picked up by the driver.
-	//readOnly := request.GetTransaction().GetBegin().GetReadOnly()
-	//if readOnly == nil {
-	//	t.Fatal("missing readOnly on ExecuteSqlRequest")
-	//}
+	readOnly := request.GetTransaction().GetBegin().GetReadOnly()
+	if readOnly == nil {
+		t.Fatal("missing readOnly on ExecuteSqlRequest")
+	}
 }
 
 func TestBeginTransactionDeferrable(t *testing.T) {


### PR DESCRIPTION
The mock server would re-use the ResultSetMetadata from the result that had been set for a query for multiple requests. This could cause the TransactionId field to be set multiple times, and potentially also cause data races if there were multiple concurrent requests reading the same result.

This fix also cleans up some other tests that started failing while fixing this issue.

Fixes #614