### PR TITLE
test: retry .NET wrapper tests

### DIFF
--- a/.github/workflows/spanner-lib-tests.yml
+++ b/.github/workflows/spanner-lib-tests.yml
@@ -145,5 +145,12 @@ jobs:
         working-directory: spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests
         run: |
           dotnet --version
-          dotnet test --no-build --verbosity normal -c Release
+          # Retry the tests 3 times before the step actually fails.
+          # We do this because the tests are executed using both the internal gRPC server and using a shared
+          # native library. The latter is not really supported due to an incompatibility between the .NET and Go
+          # runtimes, but we still run the tests here to have as much coverage as possible.
+          (echo "===== .NET Tests Attempt 1   ====" && dotnet test --no-build --verbosity normal -c Release) || \
+          (echo "===== .NET Tests Attempt 2   ====" && dotnet test --no-build --verbosity normal -c Release) || \
+          (echo "===== .NET Tests Attempt 3   ====" && dotnet test --no-build --verbosity normal -c Release) || \
+          (echo "===== .NET Tests Step Failed ====" && exit 1)
         shell: bash


### PR DESCRIPTION
Retry the .NET wrapper tests if these fail, as they often crash due to the known incompatibility between the .NET and Go runtimes.

Fixes #624