### PR TITLE
chore: return stats for batch DML in multi-statement strings

### DIFF
--- a/multi_statement_rows.go
+++ b/multi_statement_rows.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/go-sql-spanner/parser"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -212,7 +213,7 @@ func queryDmlBatch(ctx context.Context, conn *conn, index int, result *multiStat
 	}
 	for i, m := range modified {
 		if noRows, ok := result.results[startIndex+i].(*emptyRows); ok {
-			noRows.rowsAffected = m
+			noRows.stats = &sppb.ResultSetStats{RowCount: &sppb.ResultSetStats_RowCountExact{RowCountExact: m}}
 		}
 	}
 	return endIndex - startIndex, nil

--- a/rows.go
+++ b/rows.go
@@ -485,11 +485,7 @@ func (r *rows) nextStats(dest []driver.Value) error {
 
 var _ driver.Rows = (*emptyRows)(nil)
 var _ driver.RowsNextResultSet = (*emptyRows)(nil)
-var emptyRowsMetadata = &sppb.ResultSetMetadata{
-	RowType: &sppb.StructType{
-		Fields: []*sppb.StructType_Field{{Name: "affected_rows", Type: &sppb.Type{Code: sppb.TypeCode_INT64}}},
-	},
-}
+var emptyRowsMetadata = &sppb.ResultSetMetadata{RowType: &sppb.StructType{Fields: []*sppb.StructType_Field{}}}
 var emptyRowsStats = &sppb.ResultSetStats{}
 
 type emptyRows struct {
@@ -500,7 +496,7 @@ type emptyRows struct {
 
 	hasReturnedResultSetMetadata bool
 	hasReturnedResultSetStats    bool
-	rowsAffected                 int64
+	stats                        *sppb.ResultSetStats
 }
 
 func createDriverResultRows(_ driver.Result, cancel context.CancelFunc, opts *ExecOptions) *emptyRows {
@@ -579,6 +575,10 @@ func (e *emptyRows) nextStats(dest []driver.Value) error {
 		return io.EOF
 	}
 	e.hasReturnedResultSetStats = true
-	dest[0] = emptyRowsStats
+	if e.stats == nil {
+		dest[0] = emptyRowsStats
+	} else {
+		dest[0] = e.stats
+	}
 	return nil
 }

--- a/spannerlib/api/connection.go
+++ b/spannerlib/api/connection.go
@@ -328,12 +328,16 @@ func execute(ctx, directExecuteContext context.Context, conn *Connection, execut
 		return 0, err
 	}
 	id := conn.resultsIdx.Add(1)
-	if len(res.metadata.RowType.Fields) == 0 {
+	if !hasFields(res.metadata) {
 		// No rows returned. Read the stats now.
 		_ = res.readStats(ctx)
 	}
 	conn.results.Store(id, res)
 	return id, nil
+}
+
+func hasFields(metadata *spannerpb.ResultSetMetadata) bool {
+	return metadata != nil && metadata.RowType != nil && metadata.RowType.Fields != nil && len(metadata.RowType.Fields) > 0
 }
 
 func executeBatch(ctx context.Context, conn *Connection, executor queryExecutor, statements []*spannerpb.ExecuteBatchDmlRequest_Statement) (*spannerpb.ExecuteBatchDmlResponse, error) {

--- a/spannerlib/api/rows_test.go
+++ b/spannerlib/api/rows_test.go
@@ -20,10 +20,14 @@ import (
 	"reflect"
 	"testing"
 
+	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/go-sql-spanner/testutil"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestExecute(t *testing.T) {
@@ -90,6 +94,17 @@ func TestExecuteMultiStatement(t *testing.T) {
 	defer teardown()
 	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
 
+	// Add a generic successful DDL response to the mock server.
+	var expectedResponse = &emptypb.Empty{}
+	anyMsg, _ := anypb.New(expectedResponse)
+	server.TestDatabaseAdmin.SetResps([]proto.Message{
+		&longrunningpb.Operation{
+			Done:   true,
+			Result: &longrunningpb.Operation_Response{Response: anyMsg},
+			Name:   "test-operation",
+		},
+	})
+
 	poolId, err := CreatePool(ctx, dsn)
 	if err != nil {
 		t.Fatalf("CreatePool returned unexpected error: %v", err)
@@ -98,56 +113,177 @@ func TestExecuteMultiStatement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateConnection returned unexpected error: %v", err)
 	}
-	rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{
-		Sql: fmt.Sprintf("%s;%s", testutil.SelectFooFromBar, testutil.SelectFooFromBar),
-	})
-	if rowsId == 0 {
-		t.Fatal("Execute returned unexpected zero id")
+
+	type expectedResults struct {
+		numRows  int
+		affected int64
+	}
+	type test struct {
+		name               string
+		sql                string
+		numExecuteRequests int
+		numBachDmlRequests int
+		expectedResults    []expectedResults
 	}
 
-	totalRowCount := 0
-	for {
-		rowCount := 0
-		for {
-			row, err := Next(ctx, poolId, connId, rowsId)
+	for _, tt := range []test{
+		{
+			name:               "two queries",
+			sql:                fmt.Sprintf("%s;%s", testutil.SelectFooFromBar, testutil.SelectFooFromBar),
+			numExecuteRequests: 2,
+			expectedResults: []expectedResults{
+				{numRows: 2},
+				{numRows: 2},
+			},
+		},
+		{
+			name:               "three queries",
+			sql:                fmt.Sprintf("%s;%s;%s", testutil.SelectFooFromBar, testutil.SelectFooFromBar, testutil.SelectFooFromBar),
+			numExecuteRequests: 3,
+			expectedResults: []expectedResults{
+				{numRows: 2},
+				{numRows: 2},
+				{numRows: 2},
+			},
+		},
+		{
+			name:               "two DML statements",
+			sql:                fmt.Sprintf("%s;%s", testutil.UpdateBarSetFoo, testutil.UpdateBarSetFoo),
+			numBachDmlRequests: 1,
+			expectedResults: []expectedResults{
+				{affected: testutil.UpdateBarSetFooRowCount},
+				{affected: testutil.UpdateBarSetFooRowCount},
+			},
+		},
+		{
+			name:            "two DDL statements",
+			sql:             "create table my_table (id int64 primary key, value varchar(max)); create index my_index on my_table (value);",
+			expectedResults: []expectedResults{{}, {}},
+		},
+		{
+			name:               "query then DML",
+			sql:                fmt.Sprintf("%s;%s", testutil.SelectFooFromBar, testutil.UpdateBarSetFoo),
+			numExecuteRequests: 2,
+			expectedResults: []expectedResults{
+				{numRows: 2},
+				{affected: testutil.UpdateBarSetFooRowCount},
+			},
+		},
+		{
+			name:               "DML then query",
+			sql:                fmt.Sprintf("%s;%s", testutil.UpdateBarSetFoo, testutil.SelectFooFromBar),
+			numExecuteRequests: 2,
+			expectedResults: []expectedResults{
+				{affected: testutil.UpdateBarSetFooRowCount},
+				{numRows: 2},
+			},
+		},
+		{
+			name:               "query then DDL",
+			sql:                fmt.Sprintf("%s;%s", testutil.SelectFooFromBar, "create table my_table (id int64 primary key, value varchar(max));"),
+			numExecuteRequests: 1,
+			expectedResults: []expectedResults{
+				{numRows: 2},
+				{},
+			},
+		},
+		{
+			name:               "DDL then query",
+			sql:                fmt.Sprintf("%s;%s", "create table my_table (id int64 primary key)", testutil.SelectFooFromBar),
+			numExecuteRequests: 1,
+			expectedResults: []expectedResults{
+				{},
+				{numRows: 2},
+			},
+		},
+		{
+			name:               "DML then DDL",
+			sql:                fmt.Sprintf("%s;%s", testutil.UpdateBarSetFoo, "create table my_table (id int64 primary key, value varchar(max));"),
+			numExecuteRequests: 1,
+			expectedResults: []expectedResults{
+				{affected: testutil.UpdateBarSetFooRowCount},
+				{},
+			},
+		},
+		{
+			name:               "DDL then DML",
+			sql:                fmt.Sprintf("%s;%s", "create table my_table (id int64 primary key)", testutil.UpdateBarSetFoo),
+			numExecuteRequests: 1,
+			expectedResults: []expectedResults{
+				{},
+				{affected: testutil.UpdateBarSetFooRowCount},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{
+				Sql: tt.sql,
+			})
 			if err != nil {
-				t.Fatalf("Next returned unexpected error: %v", err)
+				t.Fatalf("Execute returned unexpected error: %v", err)
 			}
-			if row == nil {
-				break
+			if rowsId == 0 {
+				t.Fatal("Execute returned unexpected zero id")
 			}
-			rowCount++
-			totalRowCount++
-		}
-		if g, w := rowCount, 2; g != w {
-			t.Fatalf("row count mismatch\n Got: %d\nWant: %d", g, w)
-		}
-		metadata, err := NextResultSet(ctx, poolId, connId, rowsId)
-		if err != nil {
-			t.Fatalf("NextResultSet returned unexpected error: %v", err)
-		}
-		if metadata == nil {
-			break
-		}
-	}
-	if g, w := totalRowCount, 4; g != w {
-		t.Fatalf("total row count mismatch\n Got: %d\nWant: %d", g, w)
+
+			numResultSets := 0
+			for {
+				rowCount := 0
+				for {
+					row, err := Next(ctx, poolId, connId, rowsId)
+					if err != nil {
+						t.Fatalf("Next returned unexpected error: %v", err)
+					}
+					if row == nil {
+						break
+					}
+					rowCount++
+				}
+				if g, w := rowCount, tt.expectedResults[numResultSets].numRows; g != w {
+					t.Fatalf("row count mismatch\n Got: %d\nWant: %d", g, w)
+				}
+				stats, err := ResultSetStats(ctx, poolId, connId, rowsId)
+				if err != nil {
+					t.Fatalf("ResultSetStats returned unexpected error: %v", err)
+				}
+				if g, w := stats.GetRowCountExact(), tt.expectedResults[numResultSets].affected; g != w {
+					t.Fatalf("update count mismatch\n Got: %d\nWant: %d", g, w)
+				}
+
+				numResultSets++
+
+				metadata, err := NextResultSet(ctx, poolId, connId, rowsId)
+				if err != nil {
+					t.Fatalf("NextResultSet returned unexpected error: %v", err)
+				}
+				if metadata == nil {
+					break
+				}
+			}
+			if g, w := numResultSets, len(tt.expectedResults); g != w {
+				t.Fatalf("num result sets mismatch\n Got: %d\nWant: %d", g, w)
+			}
+			requests := server.TestSpanner.DrainRequestsFromServer()
+			executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+			batchDmlRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteBatchDmlRequest{}))
+			if g, w := len(executeRequests), tt.numExecuteRequests; g != w {
+				t.Fatalf("num ExecuteSql requests mismatch\n Got: %d\nWant: %d", g, w)
+			}
+			if g, w := len(batchDmlRequests), tt.numBachDmlRequests; g != w {
+				t.Fatalf("num BatchDml requests mismatch\n Got: %d\nWant: %d", g, w)
+			}
+
+			if err := CloseRows(ctx, poolId, connId, rowsId); err != nil {
+				t.Fatalf("CloseRows returned unexpected error: %v", err)
+			}
+		})
 	}
 
-	if err := CloseRows(ctx, poolId, connId, rowsId); err != nil {
-		t.Fatalf("CloseRows returned unexpected error: %v", err)
-	}
 	if err := CloseConnection(ctx, poolId, connId); err != nil {
 		t.Fatalf("CloseConnection returned unexpected error: %v", err)
 	}
 	if err := ClosePool(ctx, poolId); err != nil {
 		t.Fatalf("ClosePool returned unexpected error: %v", err)
-	}
-
-	requests := server.TestSpanner.DrainRequestsFromServer()
-	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
-	if g, w := len(executeRequests), 2; g != w {
-		t.Fatalf("num ExecuteSql requests mismatch\n Got: %d\nWant: %d", g, w)
 	}
 }
 


### PR DESCRIPTION
Multiple consequtive DML statements in a single SQL string are executed using Batch DML. However, the returned results for these statements did not include ResultSetStats, which meant that the update count was not returned correctly in SpannerLib.

Fixes #648