### PR TITLE
test: fix `TestTransactionTimeoutSecondStatement` by increasing timeout

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -323,14 +323,14 @@ func TestTransactionTimeoutSecondStatement(t *testing.T) {
 	ctx := context.Background()
 
 	tx, _ := db.BeginTx(ctx, &sql.TxOptions{})
-	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=20ms"); err != nil {
+	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=1000ms"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := tx.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
 		t.Fatal(err)
 	}
 
-	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 50 * time.Millisecond})
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 1500 * time.Millisecond})
 	rows, err := tx.QueryContext(ctx, testutil.SelectFooFromBar, ExecOptions{DirectExecuteQuery: true})
 	if rows != nil {
 		_ = rows.Close()


### PR DESCRIPTION
**Which issue this PR fixes**
Fixes [#625](https://github.com/googleapis/go-sql-spanner/issues/625)

### Problem
The test is flaky in CI because the local transaction_timeout(20ms) is too tight to complete the update operation, leading to a `context deadline exceeded` error or `spanner: code = "DeadlineExceeded"...` error.

### Solution
Increase the `transaction_timeout` to 1s and the `MinimumExecutionTime` to 1.5s.
I executed the tests by running 10,000 times with the `-race` flag:
- `transaction_timeout` = 1s, Passed
- `transaction_timeout` = 0.06s, Failed
- `transaction_timeout` = 0.2s, Failed
- `transaction_timeout` = 0.5s, Failed

### Verification
The test now passes on my local machine after running it 10,000 times using a loop to simulate the flaky behavior within 10,521 seconds. 
```bash
go test -v -count=10000 -race -run "TestTransactionTimeoutSecondStatement" -failfast -timeout=200m
```

I observed several pass tests taking 1.88s, 1.84s, and 1.81s with `transaction_timeout` = 1s, which proves that increasing `transaction_timeout` is necessary to prevent CI rerun.