### PR TITLE
chore(ruby): Added handling for metadata and next_result_set methods when rows object is closed.

### DIFF
--- a/spannerlib/wrappers/spannerlib-ruby/lib/spannerlib/rows.rb
+++ b/spannerlib/wrappers/spannerlib-ruby/lib/spannerlib/rows.rb
@@ -53,6 +53,8 @@ module SpannerLib
     def next_result_set
       return nil if @closed
 
+      @stats = nil
+
       res = SpannerLib.next_result_set(connection.pool_id, connection.conn_id, id)
 
       if res.nil? || res.empty?


### PR DESCRIPTION
chore(ruby): Added handling for metadata and next_result_set methods when rows object is closed.