### PR TITLE
chore: make sure closing more than once is a no-op

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gorm/
 .idea
+.DS_Store

--- a/spannerlib/api/connection.go
+++ b/spannerlib/api/connection.go
@@ -35,6 +35,10 @@ import (
 func CloseConnection(ctx context.Context, poolId, connId int64) error {
 	pool, err := findPool(poolId)
 	if err != nil {
+		// Ignore NotFound errors to ensure that closing a non-existing connection is a no-op.
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
 		return err
 	}
 	c, ok := pool.connections.LoadAndDelete(connId)

--- a/spannerlib/api/connection_test.go
+++ b/spannerlib/api/connection_test.go
@@ -71,6 +71,10 @@ func TestCreateAndCloseConnection(t *testing.T) {
 	if err := ClosePool(ctx, poolId); err != nil {
 		t.Fatalf("ClosePool returned unexpected error: %v", err)
 	}
+	// Closing a connection after its pool has been closed should be a no-op.
+	if err := CloseConnection(ctx, poolId, connId); err != nil {
+		t.Fatalf("CloseConnection returned unexpected error: %v", err)
+	}
 }
 
 func TestCreateConnectionWithUnknownPool(t *testing.T) {

--- a/spannerlib/api/rows.go
+++ b/spannerlib/api/rows.go
@@ -115,6 +115,10 @@ func next(ctx context.Context, poolId, connId, rowsId int64, marshalResult bool)
 func CloseRows(ctx context.Context, poolId, connId, rowsId int64) error {
 	conn, err := findConnection(poolId, connId)
 	if err != nil {
+		// Ignore NotFound errors to ensure that closing a non-existing rows object is a no-op.
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
 		return err
 	}
 	r, ok := conn.results.LoadAndDelete(rowsId)

--- a/spannerlib/api/rows_test.go
+++ b/spannerlib/api/rows_test.go
@@ -81,6 +81,10 @@ func TestExecute(t *testing.T) {
 	if err := CloseConnection(ctx, poolId, connId); err != nil {
 		t.Fatalf("CloseConnection returned unexpected error: %v", err)
 	}
+	// Closing a Rows object after closing its connection should be a no-op.
+	if err := CloseRows(ctx, poolId, connId, rowsId); err != nil {
+		t.Fatalf("CloseRows returned unexpected error: %v", err)
+	}
 	if err := ClosePool(ctx, poolId); err != nil {
 		t.Fatalf("ClosePool returned unexpected error: %v", err)
 	}

--- a/spannerlib/grpc-server/server.go
+++ b/spannerlib/grpc-server/server.go
@@ -136,6 +136,9 @@ func (s *spannerLibServer) ExecuteStreaming(request *pb.ExecuteRequest, stream g
 
 	first := true
 	for {
+		if queryContext.Err() != nil {
+			return queryContext.Err()
+		}
 		if row, err := api.Next(queryContext, request.Connection.Pool.Id, request.Connection.Id, id); err != nil {
 			return err
 		} else {

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
@@ -43,12 +43,22 @@ public class StreamingRows : Rows
 
     protected override void Dispose(bool disposing)
     {
+        Cleanup();
+    }
+
+    protected override ValueTask DisposeAsyncCore()
+    {
+        Cleanup();
+        return ValueTask.CompletedTask;
+    }
+    
+    private void Cleanup()
+    {
         if (!_done)
         {
             MarkDone();
         }
         _stream.Dispose();
-        base.Dispose(disposing);
     }
     
     private void MarkDone()

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
@@ -174,7 +174,6 @@ public class Server : IDisposable
             return;
         }
         _process.Kill();
-        _process.WaitForExit();
     }
 
     protected virtual void Dispose(bool disposing)

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-tests/ServerTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-tests/ServerTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
 using Google.Cloud.SpannerLib.V1;
 
 namespace Google.Cloud.SpannerLib.Grpc;
@@ -45,6 +46,12 @@ public class Tests
         Assert.That(info, Is.Not.Null);
         
         _server.Stop();
+        var watch = Stopwatch.StartNew();
+        // Give the server a couple of seconds to stop.
+        while (_server.IsRunning && watch.ElapsedMilliseconds < 2000)
+        {
+            // Wait until the server has stopped.
+        }
         Assert.That(_server.IsRunning, Is.False);
     }
 }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
@@ -159,15 +159,6 @@ public class RowsTests : AbstractMockServerTests
         // The error is 'Connection not found' or an internal exception from the underlying driver, depending on exactly
         // when the driver detects that the connection and all related objects have been closed.
         Assert.That(exception.Code is Code.NotFound or Code.Unknown, Is.True);
-
-        if (libType == LibType.Shared)
-        {
-            // TODO: Remove this once it has been fixed in the shared library.
-            //       Closing a Rows object that has already been closed because the connection has been closed, should
-            //       be a no-op.
-            var closeException = Assert.Throws<SpannerException>(() => rows.Close());
-            Assert.That(closeException.Code, Is.EqualTo(Code.NotFound));
-        }
     }
 
     [Test]


### PR DESCRIPTION
Closing a Connection or a Rows object should be a no-op if its parent has already been closed.