### PR TITLE
ci: Correct PyPI repository URL for package release

### DIFF
--- a/.github/workflows/release-spannermockserver.yml
+++ b/.github/workflows/release-spannermockserver.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://test.pypi.org/p/spannermockserver
+      url: https://pypi.org/p/spannermockserver
     permissions:
       id-token: write
       contents: read
@@ -42,6 +42,5 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        packages_dir: spannerlib/wrappers/spannerlib-python/spannermockserver/dist/
+        packages-dir: spannerlib/wrappers/spannerlib-python/spannermockserver/dist/
         verbose: true
-        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Verified
* Published in https://test.pypi.org/legacy/
* Published in https://pypi.org/