### PR TITLE
chore: support tags and stale queries in SpannerLib

### DIFF
--- a/spannerlib/api/connection.go
+++ b/spannerlib/api/connection.go
@@ -487,6 +487,9 @@ func extractTimestampBound(statement *spannerpb.ExecuteSqlRequest) *spanner.Time
 			t = spanner.MinReadTimestamp(ro.GetMinReadTimestamp().AsTime())
 		} else if ro.GetReadTimestamp() != nil {
 			t = spanner.ReadTimestamp(ro.GetReadTimestamp().AsTime())
+		} else {
+			// Default to strong read.
+			t = spanner.StrongRead()
 		}
 		return &t
 	}

--- a/spannerlib/api/connection_test.go
+++ b/spannerlib/api/connection_test.go
@@ -349,6 +349,14 @@ func TestTags(t *testing.T) {
 			t.Fatalf("ExecuteSql transaction tag mismatch\n Got: %v\nWant: %v", g, w)
 		}
 	}
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+	if g, w := len(commitRequests), 1; g != w {
+		t.Fatalf("num CommitRequests mismatch\n Got: %d\nWant: %d", g, w)
+	}
+	commitRequest := commitRequests[0].(*spannerpb.CommitRequest)
+	if g, w := commitRequest.RequestOptions.TransactionTag, "my_transaction_tag"; g != w {
+		t.Fatalf("Commit transaction tag mismatch\n Got: %v\nWant: %v", g, w)
+	}
 
 	if err := ClosePool(ctx, poolId); err != nil {
 		t.Fatalf("ClosePool returned unexpected error: %v", err)


### PR DESCRIPTION
Support request tags, transaction tags, and stale query settings in SpannerLib.