### PR TITLE
perf: improve checksum calculation

### DIFF
--- a/checksum_row_iterator.go
+++ b/checksum_row_iterator.go
@@ -61,7 +61,9 @@ type checksumRowIterator struct {
 	// hash contains the current hash for the results that have been
 	// seen. It is calculated as a SHA256 checksum over all rows that so far
 	// have been returned.
-	hash hash.Hash
+	hash       hash.Hash
+	int32Buf   [4]byte
+	float64Buf [8]byte
 
 	// errIndex and err indicate any error and the index in the result set
 	// where the error occurred.
@@ -100,7 +102,7 @@ func (it *checksumRowIterator) Next() (row *spanner.Row, err error) {
 			// checksum of the columns that are included in this result. This is
 			// also used to detect the possible difference between two empty
 			// result sets with a different set of columns.
-			it.hash, err = createMetadataChecksum(it.metadata)
+			it.hash, err = it.createMetadataChecksum(it.metadata)
 			if err != nil {
 				return err
 			}
@@ -109,37 +111,34 @@ func (it *checksumRowIterator) Next() (row *spanner.Row, err error) {
 			return it.err
 		}
 		// Update the current checksum.
-		return updateChecksum(it.hash, row)
+		return it.updateChecksum(it.hash, row)
 	})
 	return row, err
 }
 
 // updateChecksum calculates the following checksum based on a current checksum
 // and a new row.
-func updateChecksum(hash hash.Hash, row *spanner.Row) error {
+func (it *checksumRowIterator) updateChecksum(hash hash.Hash, row *spanner.Row) error {
 	for i := 0; i < row.Size(); i++ {
 		var v spanner.GenericColumnValue
 		err := row.Column(i, &v)
 		if err != nil {
 			return err
 		}
-		hashValue(v.Value, hash)
+		it.hashValue(v.Value, hash)
 	}
 	return nil
 }
 
-var int32Buf [4]byte
-var float64Buf [8]byte
-
-func hashValue(value *structpb.Value, digest hash.Hash) {
+func (it *checksumRowIterator) hashValue(value *structpb.Value, digest hash.Hash) {
 	switch value.GetKind().(type) {
 	case *structpb.Value_StringValue:
-		digest.Write(intToByte(int32Buf, len(value.GetStringValue())))
+		digest.Write(intToByte(it.int32Buf, len(value.GetStringValue())))
 		digest.Write([]byte(value.GetStringValue()))
 	case *structpb.Value_NullValue:
 		digest.Write([]byte{0})
 	case *structpb.Value_NumberValue:
-		digest.Write(float64ToByte(float64Buf, value.GetNumberValue()))
+		digest.Write(float64ToByte(it.float64Buf, value.GetNumberValue()))
 	case *structpb.Value_BoolValue:
 		if value.GetBoolValue() {
 			digest.Write([]byte{1})
@@ -153,13 +152,13 @@ func hashValue(value *structpb.Value, digest hash.Hash) {
 		}
 		sort.Strings(fields)
 		for _, field := range fields {
-			digest.Write(intToByte(int32Buf, len(field)))
+			digest.Write(intToByte(it.int32Buf, len(field)))
 			digest.Write([]byte(field))
-			hashValue(value.GetStructValue().Fields[field], digest)
+			it.hashValue(value.GetStructValue().Fields[field], digest)
 		}
 	case *structpb.Value_ListValue:
 		for _, v := range value.GetListValue().GetValues() {
-			hashValue(v, digest)
+			it.hashValue(v, digest)
 		}
 	}
 }
@@ -177,12 +176,12 @@ func float64ToByte(buf [8]byte, f float64) []byte {
 // createMetadataChecksum calculates the checksum of the metadata of a result.
 // Only the column names and types are included in the checksum. Any transaction
 // metadata is not included.
-func createMetadataChecksum(metadata *sppb.ResultSetMetadata) (hash.Hash, error) {
+func (it *checksumRowIterator) createMetadataChecksum(metadata *sppb.ResultSetMetadata) (hash.Hash, error) {
 	digest := sha256.New()
 	for _, field := range metadata.RowType.Fields {
-		digest.Write(intToByte(int32Buf, len(field.Name)))
+		digest.Write(intToByte(it.int32Buf, len(field.Name)))
 		digest.Write([]byte(field.Name))
-		digest.Write(intToByte(int32Buf, int(field.Type.Code.Number())))
+		digest.Write(intToByte(it.int32Buf, int(field.Type.Code.Number())))
 	}
 	return digest, nil
 }
@@ -224,7 +223,7 @@ func (it *checksumRowIterator) retry(ctx context.Context, tx *spanner.ReadWriteS
 	for n := int64(0); n < it.nc; n++ {
 		row, err := retryIt.Next()
 		if n == 0 && (err == nil || err == iterator.Done) {
-			newHash, checksumErr = createMetadataChecksum(retryIt.Metadata)
+			newHash, checksumErr = it.createMetadataChecksum(retryIt.Metadata)
 			if checksumErr != nil {
 				return failRetry(checksumErr)
 			}
@@ -244,7 +243,7 @@ func (it *checksumRowIterator) retry(ctx context.Context, tx *spanner.ReadWriteS
 			}
 			return failRetry(ErrAbortedDueToConcurrentModification)
 		}
-		err = updateChecksum(newHash, row)
+		err = it.updateChecksum(newHash, row)
 		if err != nil {
 			return failRetry(err)
 		}

--- a/driver_with_mockserver_test.go
+++ b/driver_with_mockserver_test.go
@@ -5636,19 +5636,19 @@ func nullUuid(valid bool, v string) spanner.NullUUID {
 	return spanner.NullUUID{Valid: true, UUID: uuid.MustParse(v)}
 }
 
-func setupTestDBConnection(t *testing.T) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnection(t testing.TB) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	return setupTestDBConnectionWithParams(t, "")
 }
 
-func setupTestDBConnectionWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnectionWithDialect(t testing.TB, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	return setupTestDBConnectionWithParamsAndDialect(t, "", dialect)
 }
 
-func setupTestDBConnectionWithParams(t *testing.T, params string) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnectionWithParams(t testing.TB, params string) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	return setupTestDBConnectionWithParamsAndDialect(t, params, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
 }
 
-func setupTestDBConnectionWithParamsAndDialect(t *testing.T, params string, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnectionWithParamsAndDialect(t testing.TB, params string, dialect databasepb.DatabaseDialect) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	server, _, serverTeardown := setupMockedTestServerWithDialect(t, dialect)
 	db, err := sql.Open(
 		"spanner",
@@ -5663,7 +5663,7 @@ func setupTestDBConnectionWithParamsAndDialect(t *testing.T, params string, dial
 	}
 }
 
-func setupTestDBConnectionWithConfigurator(t *testing.T, params string, configurator func(config *spanner.ClientConfig, opts *[]option.ClientOption)) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnectionWithConfigurator(t testing.TB, params string, configurator func(config *spanner.ClientConfig, opts *[]option.ClientOption)) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	server, _, serverTeardown := setupMockedTestServer(t)
 	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true;%s", server.Address, params)
 	config, err := ExtractConnectorConfig(dsn)
@@ -5684,7 +5684,7 @@ func setupTestDBConnectionWithConfigurator(t *testing.T, params string, configur
 	}
 }
 
-func setupTestDBConnectionWithConnectorConfig(t *testing.T, config ConnectorConfig) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
+func setupTestDBConnectionWithConnectorConfig(t testing.TB, config ConnectorConfig) (db *sql.DB, server *testutil.MockedSpannerInMemTestServer, teardown func()) {
 	server, _, serverTeardown := setupMockedTestServer(t)
 	config.Host = server.Address
 	if config.Params == nil {
@@ -5703,23 +5703,23 @@ func setupTestDBConnectionWithConnectorConfig(t *testing.T, config ConnectorConf
 	}
 }
 
-func setupMockedTestServer(t *testing.T) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+func setupMockedTestServer(t testing.TB) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfig(t, spanner.ClientConfig{})
 }
 
-func setupMockedTestServerWithDialect(t *testing.T, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+func setupMockedTestServerWithDialect(t testing.TB, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, spanner.ClientConfig{}, []option.ClientOption{}, dialect)
 }
 
-func setupMockedTestServerWithConfig(t *testing.T, config spanner.ClientConfig) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+func setupMockedTestServerWithConfig(t testing.TB, config spanner.ClientConfig) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfigAndClientOptions(t, config, []option.ClientOption{})
 }
 
-func setupMockedTestServerWithConfigAndClientOptions(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+func setupMockedTestServerWithConfigAndClientOptions(t testing.TB, config spanner.ClientConfig, clientOptions []option.ClientOption) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	return setupMockedTestServerWithConfigAndClientOptionsAndDialect(t, config, clientOptions, databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
 }
 
-func setupMockedTestServerWithConfigAndClientOptionsAndDialect(t *testing.T, config spanner.ClientConfig, clientOptions []option.ClientOption, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
+func setupMockedTestServerWithConfigAndClientOptionsAndDialect(t testing.TB, config spanner.ClientConfig, clientOptions []option.ClientOption, dialect databasepb.DatabaseDialect) (server *testutil.MockedSpannerInMemTestServer, client *spanner.Client, teardown func()) {
 	server, opts, serverTeardown := testutil.NewMockedSpannerInMemTestServer(t)
 	server.SetupSelectDialectResult(dialect)
 

--- a/testutil/mocked_inmem_server.go
+++ b/testutil/mocked_inmem_server.go
@@ -90,14 +90,14 @@ type MockedSpannerInMemTestServer struct {
 // NewMockedSpannerInMemTestServer creates a MockedSpannerInMemTestServer at
 // localhost with a random port and returns client options that can be used
 // to connect to it.
-func NewMockedSpannerInMemTestServer(t *testing.T) (mockedServer *MockedSpannerInMemTestServer, opts []option.ClientOption, teardown func()) {
+func NewMockedSpannerInMemTestServer(t testing.TB) (mockedServer *MockedSpannerInMemTestServer, opts []option.ClientOption, teardown func()) {
 	return NewMockedSpannerInMemTestServerWithAddr(t, "localhost:0")
 }
 
 // NewMockedSpannerInMemTestServerWithAddr creates a MockedSpannerInMemTestServer
 // at a given listening address and returns client options that can be used
 // to connect to it.
-func NewMockedSpannerInMemTestServerWithAddr(t *testing.T, addr string) (mockedServer *MockedSpannerInMemTestServer, opts []option.ClientOption, teardown func()) {
+func NewMockedSpannerInMemTestServerWithAddr(t testing.TB, addr string) (mockedServer *MockedSpannerInMemTestServer, opts []option.ClientOption, teardown func()) {
 	mockedServer = &MockedSpannerInMemTestServer{}
 	opts = mockedServer.setupMockedServerWithAddr(t, addr)
 	return mockedServer, opts, func() {
@@ -108,7 +108,7 @@ func NewMockedSpannerInMemTestServerWithAddr(t *testing.T, addr string) (mockedS
 	}
 }
 
-func (s *MockedSpannerInMemTestServer) setupMockedServerWithAddr(t *testing.T, addr string) []option.ClientOption {
+func (s *MockedSpannerInMemTestServer) setupMockedServerWithAddr(t testing.TB, addr string) []option.ClientOption {
 	s.TestSpanner = NewInMemSpannerServer()
 	s.TestInstanceAdmin = NewInMemInstanceAdminServer()
 	s.TestDatabaseAdmin = NewInMemDatabaseAdminServer()
@@ -128,7 +128,9 @@ func (s *MockedSpannerInMemTestServer) setupMockedServerWithAddr(t *testing.T, a
 	if err != nil {
 		t.Fatal(err)
 	}
-	go s.server.Serve(lis)
+	go func() {
+		_ = s.server.Serve(lis)
+	}()
 
 	s.Address = lis.Addr().String()
 	opts := []option.ClientOption{
@@ -141,23 +143,23 @@ func (s *MockedSpannerInMemTestServer) setupMockedServerWithAddr(t *testing.T, a
 
 func (s *MockedSpannerInMemTestServer) SetupSelectDialectResult(dialect databasepb.DatabaseDialect) {
 	result := &StatementResult{Type: StatementResultResultSet, ResultSet: CreateSelectDialectResultSet(dialect)}
-	s.TestSpanner.PutStatementResult(selectDialect, result)
+	_ = s.TestSpanner.PutStatementResult(selectDialect, result)
 }
 
 func (s *MockedSpannerInMemTestServer) setupSelect1Result() {
 	result := &StatementResult{Type: StatementResultResultSet, ResultSet: CreateSelect1ResultSet()}
-	s.TestSpanner.PutStatementResult("SELECT 1", result)
+	_ = s.TestSpanner.PutStatementResult("SELECT 1", result)
 }
 
 func (s *MockedSpannerInMemTestServer) setupFooResults() {
 	resultSet := CreateSingleColumnInt64ResultSet(selectFooFromBarResults, "FOO")
 	result := &StatementResult{Type: StatementResultResultSet, ResultSet: resultSet}
-	s.TestSpanner.PutStatementResult(SelectFooFromBar, result)
-	s.TestSpanner.PutStatementResult(UpdateBarSetFoo, &StatementResult{
+	_ = s.TestSpanner.PutStatementResult(SelectFooFromBar, result)
+	_ = s.TestSpanner.PutStatementResult(UpdateBarSetFoo, &StatementResult{
 		Type:        StatementResultUpdateCount,
 		UpdateCount: UpdateBarSetFooRowCount,
 	})
-	s.TestSpanner.PutStatementResult(UpdateSingersSetLastName, &StatementResult{
+	_ = s.TestSpanner.PutStatementResult(UpdateSingersSetLastName, &StatementResult{
 		Type:        StatementResultUpdateCount,
 		UpdateCount: UpdateSingersSetLastNameRowCount,
 	})
@@ -175,7 +177,7 @@ func (s *MockedSpannerInMemTestServer) setupSingersResults() {
 		Rows:     rows,
 	}
 	result := &StatementResult{Type: StatementResultResultSet, ResultSet: resultSet}
-	s.TestSpanner.PutStatementResult(SelectSingerIDAlbumIDAlbumTitleFromAlbums, result)
+	_ = s.TestSpanner.PutStatementResult(SelectSingerIDAlbumIDAlbumTitleFromAlbums, result)
 }
 
 // CreateSingleRowSingersResult creates a result set containing a single row of

--- a/transaction.go
+++ b/transaction.go
@@ -498,6 +498,9 @@ func (tx *readWriteTransaction) runWithRetry(ctx context.Context, f func(ctx con
 		if err == nil {
 			err = f(ctx)
 		}
+		if err == nil {
+			return
+		}
 		if err == ErrAbortedDueToConcurrentModification {
 			tx.logger.Log(ctx, LevelNotice, "transaction retry failed due to a concurrent modification")
 			return

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -357,3 +357,63 @@ func TestTransactionTimeoutSecondStatement(t *testing.T) {
 		t.Fatalf("rollback requests count mismatch\n Got: %v\nWant: %v", g, w)
 	}
 }
+
+func BenchmarkReadWriteTransaction(b *testing.B) {
+	db, server, teardown := setupTestDBConnection(b)
+	defer teardown()
+	ctx := context.Background()
+	query := "select * from random_table"
+
+	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
+		resultSet := testutil.CreateRandomResultSet(numRows)
+		_ = server.TestSpanner.PutStatementResult(query, &testutil.StatementResult{
+			Type:      testutil.StatementResultResultSet,
+			ResultSet: resultSet,
+		})
+
+		b.Run(fmt.Sprintf("num-rows-%d", numRows), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+				if err != nil {
+					b.Fatal(err)
+				}
+				//if _, err := tx.ExecContext(ctx, "set local retry_aborts_internally = false"); err != nil {
+				//	b.Fatal(err)
+				//}
+				if _, err := tx.ExecContext(ctx, "set local transaction_tag = 'my_tag'"); err != nil {
+					b.Fatal(err)
+				}
+				rows, err := tx.QueryContext(ctx, query)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for rows.Next() {
+					// Just iterate through the results
+				}
+				if rows.Err() != nil {
+					b.Fatal(rows.Err())
+				}
+				for range 10 {
+					if _, err = tx.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if _, err := tx.ExecContext(ctx, "start batch dml"); err != nil {
+					b.Fatal(err)
+				}
+				for range 10 {
+					if _, err = tx.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if _, err := tx.ExecContext(ctx, "run batch"); err != nil {
+					b.Fatal(err)
+				}
+				if err := tx.Commit(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Optimize the checksum calculation that is used for read/write transactions.

New implementation:

```
goos: darwin
goarch: arm64
pkg: github.com/googleapis/go-sql-spanner
cpu: Apple M3
BenchmarkChecksumRowIteratorRandom
BenchmarkChecksumRowIteratorRandom/num-rows-1
BenchmarkChecksumRowIteratorRandom/num-rows-1-8         	  134152	      8184 ns/op	   13528 B/op	     123 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-10
BenchmarkChecksumRowIteratorRandom/num-rows-10-8        	   16498	     72459 ns/op	  120690 B/op	    1335 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-100
BenchmarkChecksumRowIteratorRandom/num-rows-100-8       	    1725	    692326 ns/op	 1153975 B/op	   12781 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-1000
BenchmarkChecksumRowIteratorRandom/num-rows-1000-8      	     157	   7566917 ns/op	11375170 B/op	  130466 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-10000
BenchmarkChecksumRowIteratorRandom/num-rows-10000-8     	      14	  83402393 ns/op	112045544 B/op	 1294480 allocs/op
```

Original implementation:

```
goos: darwin
goarch: arm64
pkg: github.com/googleapis/go-sql-spanner
cpu: Apple M3
BenchmarkChecksumRowIteratorRandom
BenchmarkChecksumRowIteratorRandom/num-rows-1
BenchmarkChecksumRowIteratorRandom/num-rows-1-8         	   33792	     34931 ns/op	     908 B/op	      54 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-10
BenchmarkChecksumRowIteratorRandom/num-rows-10-8        	    4807	    249917 ns/op	    8768 B/op	     531 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-100
BenchmarkChecksumRowIteratorRandom/num-rows-100-8       	     494	   2408323 ns/op	   87580 B/op	    5301 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-1000
BenchmarkChecksumRowIteratorRandom/num-rows-1000-8      	      44	  25243051 ns/op	  870935 B/op	   53003 allocs/op
BenchmarkChecksumRowIteratorRandom/num-rows-10000
BenchmarkChecksumRowIteratorRandom/num-rows-10000-8     	       4	 259823406 ns/op	 8691096 B/op	  530018 allocs/op
```