### PR TITLE
chore: add more tests + small improvements for .NET wrapper

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Api.Gax;
@@ -176,7 +190,9 @@ public class StreamingRows : Rows
         // Read data until we reach the next result set.
         ReadUntilEnd();
         
-        return HasNextResultSet();
+        var hasNextResultSet = HasNextResultSet();
+        _pendingRow = Next();
+        return hasNextResultSet;
     }
 
     /// <summary>
@@ -192,13 +208,17 @@ public class StreamingRows : Rows
         // Read data until we reach the next result set.
         await ReadUntilEndAsync(cancellationToken).ConfigureAwait(false);
         
-        return HasNextResultSet();
+        var hasNextResultSet = HasNextResultSet();
+        _pendingRow = await NextAsync(cancellationToken).ConfigureAwait(false);
+        return hasNextResultSet;
     }
 
     private bool HasNextResultSet()
     {
         if (_pendingNextResultSetCall)
         {
+            _stats = null;
+            _metadata = null;
             _pendingNextResultSetCall = false;
             return true;
         }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/MockSpannerServer.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/MockSpannerServer.cs
@@ -58,15 +58,20 @@ public class StatementResult
     {
         return new StatementResult(exception);
     }
+    
+    public static StatementResult CreateSelectZeroResultSet()
+    {
+        return CreateSingleColumnResultSet(new Spanner.V1.Type { Code = Spanner.V1.TypeCode.Int64 }, "COL1", 0);
+    }
 
     public static StatementResult CreateSelect1ResultSet()
     {
         return CreateSingleColumnResultSet(new Spanner.V1.Type { Code = Spanner.V1.TypeCode.Int64 }, "COL1", 1);
     }
-    
-    public static StatementResult CreateSelectZeroResultSet()
+
+    public static StatementResult CreateSelect2ResultSet()
     {
-        return CreateSingleColumnResultSet(new Spanner.V1.Type { Code = Spanner.V1.TypeCode.Int64 }, "COL1", 0);
+        return CreateSingleColumnResultSet(new Spanner.V1.Type { Code = Spanner.V1.TypeCode.Int64 }, "COL1", 2);
     }
     
     public static StatementResult CreateSingleColumnResultSet(Spanner.V1.Type type, string col, params object[] values)
@@ -403,12 +408,12 @@ public class MockSpannerService : Spanner.V1.Spanner.SpannerBase
             _abortNextStatement = true;
         }
     }
-    
+
     public void ClearRequests()
     {
         _requests.Clear();
     }
-    
+
     public IEnumerable<IMessage> Requests => new List<IMessage>(_requests).AsReadOnly();
 
     /// <summary>
@@ -444,7 +449,7 @@ public class MockSpannerService : Spanner.V1.Spanner.SpannerBase
         }
         return false;
     }
-    
+
     public IEnumerable<ServerCallContext> Contexts => new List<ServerCallContext>(_contexts).AsReadOnly();
 
     public IEnumerable<Metadata> Headers => new List<Metadata>(_headers).AsReadOnly();

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/SpannerConverter.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/SpannerConverter.cs
@@ -95,7 +95,7 @@ internal static class SpannerConverter
                 {
                     return Value.ForString(XmlConvert.ToString(timeSpan));
                 }
-                return Value.ForString(value.ToString());            
+                return Value.ForString(value.ToString());
             case TypeCode.Json:
                 if (value is string stringValue)
                 {

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/SpannerMockServerFixture.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/SpannerMockServerFixture.cs
@@ -62,7 +62,7 @@ public class SpannerMockServerFixture : IDisposable
             {
                 options.MaxReceiveMessageSize = null;
             });
-        });        
+        });
         builder.ConfigureKestrel(options =>
         {
             // Set up an HTTP/2 endpoint without TLS.

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BasicTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BasicTests.cs
@@ -132,7 +132,6 @@ public class BasicTests : AbstractMockServerTests
     }
 
     [Test]
-    [Ignore("execute async disabled for now")]
     public async Task TestExecuteQueryAsync([Values] LibType libType)
     {
         using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);


### PR DESCRIPTION
Adds some more tests for the .NET wrapper and fixes some issues with multi-statement SQL strings that return errors for the second (or later) statement.

This change also removes the option to use unary RPCs to fetch results using the gRPC API in the .NET wrapper, as the performance of that is slower than using a streaming RPC. This will in a future pull request be replaced with a protocol that uses a bi-directional gRPC stream.