### PR TITLE
chore: add GetTotalUpdateCount method to .NET

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
@@ -400,27 +400,23 @@ public class RowsTests : AbstractMockServerTests
         Fixture.SpannerMock.AddOrUpdateStatementResult(query, StatementResult.CreateQuery(results));
 
         // Create a SQL string containing a mix of DML and queries.
-        var numQueries = 0;
         var builder = new StringBuilder();
         for (var i = 0; i < numDmlStatements; i++)
         {
-            while (Random.Shared.Next() % 2 == 0)
+            while (Random.Shared.Next(2) == 0)
             {
                 builder.Append(query).Append(';');
-                numQueries++;
             }
             builder.Append(dml).Append(';');
-            while (Random.Shared.Next() % 5 == 0)
+            while (Random.Shared.Next(5) == 0)
             {
                 builder.Append(query).Append(';');
-                numQueries++;
             }
         }
         var sql = builder.ToString();
-        if ("".Equals(sql))
+        if (string.IsNullOrEmpty(sql))
         {
             sql = query;
-            numQueries = 1;
         }
 
         await using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
@@ -432,7 +428,7 @@ public class RowsTests : AbstractMockServerTests
 
         // ReSharper disable once MethodHasAsyncOverload
         var totalUpdateCount = async ? await rows.GetTotalUpdateCountAsync() : rows.GetTotalUpdateCount();
-        Assert.That(totalUpdateCount, Is.EqualTo(updateCount * numDmlStatements - numQueries));
+        Assert.That(totalUpdateCount, Is.EqualTo(numDmlStatements == 0 ? -1 : updateCount * numDmlStatements));
     }
     
     [Test]

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
@@ -106,14 +106,27 @@ public class Rows : AbstractLibObject
     /// </summary>
     /// <returns>
     /// The total update count of all the result sets in this Rows object.
+    /// If the SQL string only contained non-DML statements, then the update count is -1. If the SQL string contained at
+    /// least one DML statement, then the returned value is the sum of all update counts of the DML statements in the
+    /// SQL string that was executed.
     /// </returns>
     public long GetTotalUpdateCount()
     {
-        var result = UpdateCount;
-        while (NextResultSet())
+        long result = -1;
+        var hasUpdateCount = false;
+        do
         {
-            result += UpdateCount;
-        }
+            var updateCount = UpdateCount;
+            if (updateCount > -1)
+            {
+                if (!hasUpdateCount)
+                {
+                    hasUpdateCount = true;
+                    result = 0;
+                }
+                result += updateCount;
+            }
+        } while (NextResultSet());
         return result;
     }
 
@@ -124,14 +137,27 @@ public class Rows : AbstractLibObject
     /// </summary>
     /// <returns>
     /// The total update count of all the result sets in this Rows object.
+    /// If the SQL string only contained non-DML statements, then the update count is -1. If the SQL string contained at
+    /// least one DML statement, then the returned value is the sum of all update counts of the DML statements in the
+    /// SQL string that was executed.
     /// </returns>
     public async Task<long> GetTotalUpdateCountAsync(CancellationToken cancellationToken = default)
     {
-        var result = UpdateCount;
-        while (await NextResultSetAsync(cancellationToken).ConfigureAwait(false))
+        long result = -1;
+        var hasUpdateCount = false;
+        do
         {
-            result += UpdateCount;
-        }
+            var updateCount = UpdateCount;
+            if (updateCount > -1)
+            {
+                if (!hasUpdateCount)
+                {
+                    hasUpdateCount = true;
+                    result = 0;
+                }
+                result += updateCount;
+            }
+        } while (await NextResultSetAsync(cancellationToken).ConfigureAwait(false));
         return result;
     }
 


### PR DESCRIPTION
Add a GetTotalUpdateCount method to the .NET wrapper that can be used to return the total update count of a set of SQL statements. This will be used by the ADO.NET ExecuteNonQuery method.

See https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.executenonquery