### PR TITLE
chore: use execContext for DML statements in batch

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BatchTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BatchTests.cs
@@ -22,13 +22,17 @@ namespace Google.Cloud.SpannerLib.Tests;
 public class BatchTests : AbstractMockServerTests
 {
     [Test]
-    public void TestBatchDml([Values] LibType libType)
+    public void TestBatchDml([Values] LibType libType, [Values] bool useTransaction)
     {
         var insert = "insert into test (id, value) values (@id, @value)";
         Fixture.SpannerMock.AddOrUpdateStatementResult(insert, StatementResult.CreateUpdateCount(1));
         
         using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
         using var connection = pool.CreateConnection();
+        if (useTransaction)
+        {
+            connection.BeginTransaction(new TransactionOptions());
+        }
         var updateCounts = connection.ExecuteBatch([
             new ExecuteBatchDmlRequest.Types.Statement {Sql = insert, Params = new Struct
             {
@@ -47,8 +51,60 @@ public class BatchTests : AbstractMockServerTests
                 },
             }},
         ]);
+        if (useTransaction)
+        {
+            connection.Commit();
+        }
         Assert.That(updateCounts, Is.EqualTo(new long[]{1,1}));
         Assert.That(Fixture.SpannerMock.Requests.OfType<ExecuteBatchDmlRequest>().Count(), Is.EqualTo(1));
+    }
+    
+    [Test]
+    public void TestBatchDmlScript([Values] LibType libType, [Values] bool useTransaction)
+    {
+        var insert = "insert into test (id, value) values (@id, @value)";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(insert, StatementResult.CreateUpdateCount(1));
+        
+        using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
+        using var connection = pool.CreateConnection();
+        if (useTransaction)
+        {
+            connection.BeginTransaction(new TransactionOptions());
+        }
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "start batch dml"}));
+        using (connection.Execute(new ExecuteSqlRequest
+               {
+                   Sql = insert,
+                   Params = new Struct
+                   {
+                       Fields =
+                       {
+                           ["id"] = Value.ForString("1"),
+                           ["value"] = Value.ForString("One"),
+                       },
+                   },
+               }));
+        using (connection.Execute(new ExecuteSqlRequest
+               {
+                   Sql = insert,
+                   Params = new Struct
+                   {
+                       Fields =
+                       {
+                           ["id"] = Value.ForString("2"),
+                           ["value"] = Value.ForString("Two"),
+                       },
+                   },
+               }));
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "run batch"}));
+        if (useTransaction)
+        {
+            connection.Commit();
+        }
+        
+        Assert.That(Fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(), Is.Empty);
+        Assert.That(Fixture.SpannerMock.Requests.OfType<ExecuteBatchDmlRequest>().ToList(), Has.Count.EqualTo(1));
+        Assert.That(Fixture.SpannerMock.Requests.OfType<ExecuteBatchDmlRequest>().First().Statements, Has.Count.EqualTo(2));
     }
 
     [Test]
@@ -65,6 +121,23 @@ public class BatchTests : AbstractMockServerTests
         ]);
         Assert.That(updateCounts, Is.EqualTo(new long[]{-1,-1}));
         Assert.That(Fixture.DatabaseAdminMock.Requests.OfType<UpdateDatabaseDdlRequest>().Count(), Is.EqualTo(1));
+    }
+    
+    [Test]
+    public void TestBatchDdlScript([Values] LibType libType)
+    {
+        // We don't need to set up any results for DDL statements on the mock server.
+        // It automatically responds with an long-running operation that has finished when it receives a DDL request.
+        using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
+        using var connection = pool.CreateConnection();
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "start batch ddl"}));
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "create table my_table (id int64 primary key, value string(max))"}));
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "create index my_index on my_table (value)"}));
+        using (connection.Execute(new ExecuteSqlRequest{Sql = "run batch"}));
+        
+        Assert.That(Fixture.SpannerMock.Requests.OfType<ExecuteSqlRequest>(), Is.Empty);
+        Assert.That(Fixture.DatabaseAdminMock.Requests.OfType<UpdateDatabaseDdlRequest>().ToList(), Has.Count.EqualTo(1));
+        Assert.That(Fixture.DatabaseAdminMock.Requests.OfType<UpdateDatabaseDdlRequest>().First().Statements, Has.Count.EqualTo(2));
     }
     
 }


### PR DESCRIPTION
DML statements without a THEN RETURN clause should be executed using execContext when the connection is in a batch. This ensures that the DML statement is actually executed using the batch, instead of being executed as a single statement.