### PR TITLE
chore: fix PDML in SpannerLib

### DIFF
--- a/multi_statement_rows.go
+++ b/multi_statement_rows.go
@@ -195,7 +195,7 @@ func queryDmlBatch(ctx context.Context, conn *conn, index int, result *multiStat
 			_ = conn.AbortBatch()
 			return startIndex, err
 		} else {
-			r := createDriverResultRows(res, func() {}, execOpts)
+			r := createDriverResultRows(res /* isPartitionedDml = */, false, func() {}, execOpts)
 			result.results = append(result.results, r)
 		}
 	}

--- a/rows_test.go
+++ b/rows_test.go
@@ -158,7 +158,7 @@ func TestRows_Next_Unsupported(t *testing.T) {
 }
 
 func TestEmptyRows(t *testing.T) {
-	r := createDriverResultRows(&result{}, func() {}, &ExecOptions{})
+	r := createDriverResultRows(&result{}, false, func() {}, &ExecOptions{})
 
 	if g, w := r.Columns(), []string{"affected_rows"}; !cmp.Equal(g, w) {
 		t.Fatalf("columns mismatch\n Got: %v\nWant: %v", g, w)
@@ -169,7 +169,7 @@ func TestEmptyRows(t *testing.T) {
 }
 
 func TestEmptyRowsWithMetadataAndStats(t *testing.T) {
-	r := createDriverResultRows(&result{}, func() {}, &ExecOptions{ReturnResultSetMetadata: true, ReturnResultSetStats: true})
+	r := createDriverResultRows(&result{}, false, func() {}, &ExecOptions{ReturnResultSetMetadata: true, ReturnResultSetStats: true})
 
 	// The first result set should contain ResultSetMetadata.
 	if g, w := r.Columns(), []string{"metadata"}; !cmp.Equal(g, w) {

--- a/spannerlib/api/partitioned_dml_test.go
+++ b/spannerlib/api/partitioned_dml_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/googleapis/go-sql-spanner/testutil"
+)
+
+func TestPartitionedDml(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+
+	poolId, err := CreatePool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("CreatePool returned unexpected error: %v", err)
+	}
+	connId, err := CreateConnection(ctx, poolId)
+	if err != nil {
+		t.Fatalf("CreateConnection returned unexpected error: %v", err)
+	}
+
+	if err := executeAndDiscard(ctx, poolId, connId, "set autocommit_dml_mode='partitioned_non_atomic'"); err != nil {
+		t.Fatalf("set autocommit_dml_mode returned unexpected error: %v", err)
+	}
+	if affected, err := executeAndReturnUpdateCount(ctx, poolId, connId, testutil.UpdateBarSetFoo); err != nil {
+		t.Fatalf("execute returned unexpected error: %v", err)
+	} else {
+		if g, w := affected, int64(testutil.UpdateBarSetFooRowCount); g != w {
+			t.Fatalf("update count mismatch\n Got: %v\nWant: %v", g, w)
+		}
+	}
+
+	// Verify that the statement used Partitioned DML.
+	requests := server.TestSpanner.DrainRequestsFromServer()
+	beginRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.BeginTransactionRequest{}))
+	if g, w := len(beginRequests), 1; g != w {
+		t.Fatalf("BeginTransaction request count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	executeRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+	if g, w := len(executeRequests), 1; g != w {
+		t.Fatalf("Execute request count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	executeRequest := executeRequests[0].(*spannerpb.ExecuteSqlRequest)
+	if executeRequest.GetTransaction() == nil || len(executeRequest.GetTransaction().GetId()) == 0 {
+		t.Fatalf("missing transaction on request: %v", executeRequest)
+	}
+	// Partitioned DML is not committed.
+	commitRequests := testutil.RequestsOfType(requests, reflect.TypeOf(&spannerpb.CommitRequest{}))
+	if g, w := len(commitRequests), 0; g != w {
+		t.Fatalf("Commit request count mismatch\n Got: %v\nWant: %v", g, w)
+	}
+
+	if err := CloseConnection(ctx, poolId, connId); err != nil {
+		t.Fatalf("CloseConnection returned unexpected error: %v", err)
+	}
+	if err := ClosePool(ctx, poolId); err != nil {
+		t.Fatalf("ClosePool returned unexpected error: %v", err)
+	}
+}
+
+func executeAndDiscard(ctx context.Context, poolId, connId int64, query string) error {
+	if rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{Sql: query}); err != nil {
+		return err
+	} else {
+		_ = CloseRows(ctx, poolId, connId, rowsId)
+	}
+	return nil
+}
+
+func executeAndReturnUpdateCount(ctx context.Context, poolId, connId int64, query string) (int64, error) {
+	if rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{Sql: query}); err != nil {
+		return 0, err
+	} else {
+		defer func() { _ = CloseRows(ctx, poolId, connId, rowsId) }()
+		if stats, err := ResultSetStats(ctx, poolId, connId, rowsId); err != nil {
+			return 0, err
+		} else {
+			switch stats.GetRowCount().(type) {
+			case *spannerpb.ResultSetStats_RowCountExact:
+				return stats.GetRowCountExact(), nil
+			case *spannerpb.ResultSetStats_RowCountLowerBound:
+				return stats.GetRowCountLowerBound(), nil
+			}
+			return 0, fmt.Errorf("unexpected result set stats type: %v", stats.GetRowCount())
+		}
+	}
+}

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BasicTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/BasicTests.cs
@@ -66,7 +66,7 @@ public class BasicTests : AbstractMockServerTests
         using var connection = pool.CreateConnection();
         SpannerException exception = Assert.Throws<SpannerException>(() => connection.Execute(new ExecuteSqlRequest { Sql = sql }));
         Assert.That(exception.Code, Is.EqualTo(Code.NotFound));
-        Assert.That(exception.Message, Is.EqualTo("Table not found"));
+        Assert.That(exception.Message, Is.EqualTo($"{StatusCode.NotFound}: Table not found"));
     }
 
     [Test]

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/SpannerException.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/SpannerException.cs
@@ -24,8 +24,17 @@ namespace Google.Cloud.SpannerLib;
 /// function in SpannerLib returns a non-zero status code.
 /// </summary>
 /// <param name="status">The status that was returned by SpannerLib</param>
-public class SpannerException(Status status) : Exception(status.Message)
+public class SpannerException(Status status) : Exception(CreateMessage(status))
 {
+    private static string CreateMessage(Status status)
+    {
+        if (Enum.IsDefined(typeof(StatusCode), status.Code))
+        {
+            return $"{((StatusCode)status.Code).ToString()}: {status.Message}";
+        }
+        return status.Message;
+    }
+    
     public static SpannerException ToSpannerException(RpcException exception)
     {
         return new SpannerException(new Status { Code = (int) exception.Status.StatusCode, Message = exception.Message });


### PR DESCRIPTION
As SpannerLib executes all statements through QueryContext, and QueryContext did not support Partitioned DML, PDML statements would be executed as normal DML. This change fixes that.