### PR TITLE
feat: support partitioned queries through SQL statements

### DIFF
--- a/client_side_statement_test.go
+++ b/client_side_statement_test.go
@@ -599,7 +599,7 @@ func TestStatementExecutor_UsesExecOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	it, err := execStmt.queryContext(ctx, c, &ExecOptions{DecodeOption: DecodeOptionProto, ReturnResultSetMetadata: true, ReturnResultSetStats: true})
+	it, err := execStmt.queryContext(ctx, c, &ExecOptions{DecodeOption: DecodeOptionProto, ReturnResultSetMetadata: true, ReturnResultSetStats: true}, []driver.NamedValue{})
 	if err != nil {
 		t.Fatalf("could not get current staleness value from connection: %v", err)
 	}

--- a/conn.go
+++ b/conn.go
@@ -691,7 +691,7 @@ func (c *conn) execDDL(ctx context.Context, statements ...spanner.Statement) (dr
 			if err := stmt.Parse(c.parser, ddlStatements[0]); err != nil {
 				return nil, err
 			}
-			return (&executableDropDatabaseStatement{stmt}).execContext(ctx, c, nil)
+			return (&executableDropDatabaseStatement{stmt}).execContext(ctx, c, nil, []driver.NamedValue{})
 		}
 
 		op, err := c.adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
@@ -1039,7 +1039,7 @@ func (c *conn) queryParsed(ctx context.Context, query string, clientStmt parser.
 		if err != nil {
 			return nil, err
 		}
-		return execStmt.queryContext(ctx, c, execOptions)
+		return execStmt.queryContext(ctx, c, execOptions, args)
 	}
 	return c.queryContext(ctx, query, statementInfo, execOptions, args)
 }
@@ -1200,7 +1200,7 @@ func (c *conn) execParsed(ctx context.Context, query string, stmt parser.ParsedS
 		if err != nil {
 			return nil, err
 		}
-		return execStmt.execContext(ctx, c, execOptions)
+		return execStmt.execContext(ctx, c, execOptions, args)
 	}
 	return c.execContext(ctx, query, statementInfo, execOptions, args)
 }

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -207,7 +207,7 @@ var propertyMaxPartitions = createConnectionProperty(
 	false,
 	nil,
 	connectionstate.ContextUser,
-	connectionstate.ConvertInt64,
+	connectionstate.ConvertInt,
 )
 var propertyMaxPartitionedParallelism = createConnectionProperty(
 	"max_partitioned_parallelism",

--- a/parser/statements.go
+++ b/parser/statements.go
@@ -111,7 +111,6 @@ func isRunBatch(parser *StatementParser, query string) bool {
 		return false
 	}
 	if !sp.hasMoreTokens() {
-		// START is a synonym for START TRANSACTION
 		return false
 	}
 	if sp.eatKeyword("batch") {
@@ -126,7 +125,6 @@ func isRunPartitionedQuery(parser *StatementParser, query string) bool {
 		return false
 	}
 	if !sp.hasMoreTokens() {
-		// START is a synonym for START TRANSACTION
 		return false
 	}
 	if sp.eatKeyword("partitioned") {

--- a/parser/statements_test.go
+++ b/parser/statements_test.go
@@ -642,28 +642,28 @@ func TestParseRunPartitionedQuery(t *testing.T) {
 		{
 			input: "run partitioned query select * from my_table",
 			want: ParsedRunPartitionedQueryStatement{
-				statement: " select * from my_table",
+				Statement: " select * from my_table",
 				query:     "run partitioned query select * from my_table",
 			},
 		},
 		{
 			input: "run partitioned query\nselect * from my_table",
 			want: ParsedRunPartitionedQueryStatement{
-				statement: "\nselect * from my_table",
+				Statement: "\nselect * from my_table",
 				query:     "run partitioned query\nselect * from my_table",
 			},
 		},
 		{
 			input: "run partitioned query\n--comment\nselect * from my_table",
 			want: ParsedRunPartitionedQueryStatement{
-				statement: "\n--comment\nselect * from my_table",
+				Statement: "\n--comment\nselect * from my_table",
 				query:     "run partitioned query\n--comment\nselect * from my_table",
 			},
 		},
 		{
 			input: "run --comment\n partitioned /* comment */ query select * from my_table",
 			want: ParsedRunPartitionedQueryStatement{
-				statement: " select * from my_table",
+				Statement: " select * from my_table",
 				query:     "run --comment\n partitioned /* comment */ query select * from my_table",
 			},
 		},

--- a/statements.go
+++ b/statements.go
@@ -29,8 +29,8 @@ import (
 )
 
 type executableStatement interface {
-	execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error)
-	queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error)
+	execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error)
+	queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error)
 }
 
 func createExecutableStatement(stmt parser.ParsedStatement) (executableStatement, error) {
@@ -67,11 +67,11 @@ type executableShowStatement struct {
 	stmt *parser.ParsedShowStatement
 }
 
-func (s *executableShowStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableShowStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	return nil, spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "%q cannot be used with execContext", s.stmt.Query()))
 }
 
-func (s *executableShowStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
+func (s *executableShowStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
 	col := s.stmt.Identifier.String()
 	val, hasValue, err := c.showConnectionVariable(s.stmt.Identifier)
 	if err != nil {
@@ -113,14 +113,14 @@ type executableSetStatement struct {
 	stmt *parser.ParsedSetStatement
 }
 
-func (s *executableSetStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableSetStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	if err := s.execute(c); err != nil {
 		return nil, err
 	}
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableSetStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
+func (s *executableSetStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
 	if err := s.execute(c); err != nil {
 		return nil, err
 	}
@@ -144,14 +144,14 @@ type executableResetStatement struct {
 	stmt *parser.ParsedResetStatement
 }
 
-func (s *executableResetStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableResetStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false, false); err != nil {
 		return nil, err
 	}
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableResetStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
+func (s *executableResetStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
 	if err := c.setConnectionVariable(s.stmt.Identifier, "default", false, false, false); err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ type executableCreateDatabaseStatement struct {
 	stmt *parser.ParsedCreateDatabaseStatement
 }
 
-func (s *executableCreateDatabaseStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableCreateDatabaseStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	instance := fmt.Sprintf("projects/%s/instances/%s", c.connector.connectorConfig.Project, c.connector.connectorConfig.Instance)
 	request := &databasepb.CreateDatabaseRequest{
 		CreateStatement: s.stmt.Query(),
@@ -190,8 +190,8 @@ func (s *executableCreateDatabaseStatement) execContext(ctx context.Context, c *
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableCreateDatabaseStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableCreateDatabaseStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -201,7 +201,7 @@ type executableDropDatabaseStatement struct {
 	stmt *parser.ParsedDropDatabaseStatement
 }
 
-func (s *executableDropDatabaseStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableDropDatabaseStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	database := fmt.Sprintf(
 		"projects/%s/instances/%s/databases/%s",
 		c.connector.connectorConfig.Project,
@@ -217,8 +217,8 @@ func (s *executableDropDatabaseStatement) execContext(ctx context.Context, c *co
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableDropDatabaseStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableDropDatabaseStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -228,7 +228,7 @@ type executableStartBatchStatement struct {
 	stmt *parser.ParsedStartBatchStatement
 }
 
-func (s *executableStartBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableStartBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	switch s.stmt.Type {
 	case parser.BatchTypeDml:
 		return c.startBatchDML( /*automatic = */ false)
@@ -239,8 +239,8 @@ func (s *executableStartBatchStatement) execContext(ctx context.Context, c *conn
 	}
 }
 
-func (s *executableStartBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableStartBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -250,12 +250,12 @@ type executableRunBatchStatement struct {
 	stmt *parser.ParsedRunBatchStatement
 }
 
-func (s *executableRunBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableRunBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	return c.runBatch(ctx)
 }
 
-func (s *executableRunBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableRunBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -265,12 +265,12 @@ type executableAbortBatchStatement struct {
 	stmt *parser.ParsedAbortBatchStatement
 }
 
-func (s *executableAbortBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableAbortBatchStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	return c.abortBatch()
 }
 
-func (s *executableAbortBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableAbortBatchStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -280,12 +280,15 @@ type executableRunPartitionedQueryStatement struct {
 	stmt *parser.ParsedRunPartitionedQueryStatement
 }
 
-func (s *executableRunPartitionedQueryStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableRunPartitionedQueryStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	return nil, status.Errorf(codes.FailedPrecondition, "cannot use RUN PARTITIONED QUERY with ExecContext")
 }
 
-func (s *executableRunPartitionedQueryStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	args := []driver.NamedValue{{Value: opts}}
+func (s *executableRunPartitionedQueryStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if c.tempExecOptions == nil {
+		c.tempExecOptions = &ExecOptions{}
+	}
+	c.tempExecOptions.PartitionedQueryOptions.AutoPartitionQuery = true
 	return c.QueryContext(ctx, s.stmt.Statement, args)
 }
 
@@ -293,7 +296,7 @@ type executableBeginStatement struct {
 	stmt *parser.ParsedBeginStatement
 }
 
-func (s *executableBeginStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableBeginStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	if len(s.stmt.Identifiers) != len(s.stmt.Literals) {
 		return nil, status.Errorf(codes.InvalidArgument, "statement contains %d identifiers, but %d values given", len(s.stmt.Identifiers), len(s.stmt.Literals))
 	}
@@ -314,8 +317,8 @@ func (s *executableBeginStatement) execContext(ctx context.Context, c *conn, opt
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableBeginStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableBeginStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -325,7 +328,7 @@ type executableCommitStatement struct {
 	stmt *parser.ParsedCommitStatement
 }
 
-func (s *executableCommitStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableCommitStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	_, err := c.Commit(ctx)
 	if err != nil {
 		return nil, err
@@ -333,8 +336,8 @@ func (s *executableCommitStatement) execContext(ctx context.Context, c *conn, op
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableCommitStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableCommitStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil
@@ -344,15 +347,15 @@ type executableRollbackStatement struct {
 	stmt *parser.ParsedRollbackStatement
 }
 
-func (s *executableRollbackStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Result, error) {
+func (s *executableRollbackStatement) execContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	if err := c.Rollback(ctx); err != nil {
 		return nil, err
 	}
 	return driver.ResultNoRows, nil
 }
 
-func (s *executableRollbackStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions) (driver.Rows, error) {
-	if _, err := s.execContext(ctx, c, opts); err != nil {
+func (s *executableRollbackStatement) queryContext(ctx context.Context, c *conn, opts *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
+	if _, err := s.execContext(ctx, c, opts, args); err != nil {
 		return nil, err
 	}
 	return createEmptyRows(opts), nil

--- a/transaction.go
+++ b/transaction.go
@@ -319,7 +319,7 @@ func (tx *readOnlyTransaction) createPartitionedQuery(ctx context.Context, stmt 
 	}
 	partitionOptions := execOptions.PartitionedQueryOptions.PartitionOptions
 	if partitionOptions.MaxPartitions == 0 && partitionOptions.PartitionBytes == 0 {
-		partitionOptions.MaxPartitions = propertyMaxPartitions.GetValueOrDefault(tx.state)
+		partitionOptions.MaxPartitions = int64(propertyMaxPartitions.GetValueOrDefault(tx.state))
 	}
 	execOptions.QueryOptions.DataBoostEnabled = execOptions.QueryOptions.DataBoostEnabled || propertyDataBoostEnabled.GetValueOrDefault(tx.state)
 	partitions, err := tx.boTx.PartitionQueryWithOptions(ctx, stmt, partitionOptions, execOptions.QueryOptions)


### PR DESCRIPTION
Support partitioned queries using only SQL statements. Queries can be executed as a partitioned query like this:

```sql
run partitioned query select * from my_table where some_column=@my_param
```

The above statement is translated into:
1. An invocation of the [`PartitionQuery` RPC.](https://docs.cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.PartitionQuery)
2. N invocations of `ExecuteSqlRequest`, one for each partition that is returned by `PartitionQuery`. These invocations are executed partly in parallel using at most `max_partitioned_parallelism` goroutines.
3. The results from the N calls to `ExecuteSqlRequest` are returned as a single `sql.Rows` instance. The results are fed into the `sql.Rows` instance by background workers. The application can read from the `sql.Rows` instance while the background workers are producing rows.