### PR TITLE
feat: add option to decode NUMERIC to string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1107,7 +1107,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions *Exec
 			return nil, err
 		}
 	}
-	res := createRows(iter, cancel, execOptions)
+	res := createRows(c.state, iter, cancel, execOptions)
 	if execOptions.DirectExecuteQuery {
 		if err := c.directExecuteQuery(ctx, cancelCause, res, execOptions); err != nil {
 			return nil, err

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -255,6 +255,18 @@ var propertyDecodeToNativeArrays = createConnectionProperty(
 	connectionstate.ContextUser,
 	connectionstate.ConvertBool,
 )
+var propertyDecodeNumericToString = createConnectionProperty(
+	"decode_numeric_to_string",
+	"decode_numeric_to_string determines whether numeric values should be returned as strings or as instances "+
+		"of big.Rat. The latter is the default and is consistent with the type that is used by the Spanner Go client library. "+
+		"Decoding to string is consistent with the database/sql standard and more similar to what other database/sql drivers "+
+		"return.",
+	false,
+	false,
+	nil,
+	connectionstate.ContextUser,
+	connectionstate.ConvertBool,
+)
 
 // ------------------------------------------------------------------------------------------------
 // Transaction connection properties.

--- a/statements.go
+++ b/statements.go
@@ -103,7 +103,7 @@ func (s *executableShowStatement) queryContext(ctx context.Context, c *conn, opt
 	if err != nil {
 		return nil, err
 	}
-	return createRows(it /*cancel=*/, nil, opts), nil
+	return createRows(c.state, it /*cancel=*/, nil, opts), nil
 }
 
 // SET [SESSION | LOCAL] [my_extension.]my_property {=|to} <value>


### PR DESCRIPTION
The Spanner Go client uses big.Rat for NUMERIC values. This behavior is replicated by the Spanner database/sql driver by default. This requires applications to scan these values using a big.Rat type, which is not consistent with what other database/sql drivers use.

This change introduces an option to decode NUMERIC values to a string instead of a big.Rat. Setting this option makes the driver behave more like other database/sql drivers (e.g. like the PostgreSQL driver).