### PR TITLE
chore: disable rubocop warnings for specific logging statements

### DIFF
--- a/spannerlib/wrappers/spannerlib-ruby/spec/mock_server_runner.rb
+++ b/spannerlib/wrappers/spannerlib-ruby/spec/mock_server_runner.rb
@@ -32,7 +32,7 @@ begin
 
   File.write(ENV["MOCK_PORT_FILE"], port.to_s) if ENV["MOCK_PORT_FILE"]
 
-  puts port
+  puts port # rubocop:disable RSpec/Output
 
   server.run_till_terminated
 rescue SignalException

--- a/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
+++ b/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
@@ -51,11 +51,11 @@ Minitest.after_run do
   end
 
   if $any_failure
-    puts "Tests Failed! Exiting with code 1"
+    puts "Tests Failed! Exiting with code 1" # rubocop:disable RSpec/Output
     $stdout.flush
     Process.exit!(1)
   else
-    puts "Tests Passed! Exiting with code 0"
+    puts "Tests Passed! Exiting with code 0" # rubocop:disable RSpec/Output
     $stdout.flush
     Process.exit!(0)
   end


### PR DESCRIPTION
Disable rubocop warnings for a few logging statements to prevent test failures.