### PR TITLE
feat: support Prepare for client-side statements

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -912,7 +912,12 @@ func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, err
 	if err != nil {
 		return nil, err
 	}
-	return &stmt{conn: c, query: parsedSQL, numArgs: len(args), execOptions: execOptions}, nil
+	info := c.parser.DetectStatementType(query)
+	parsedStatement, err := c.parser.ParseClientSideStatement(query)
+	if err != nil {
+		return nil, err
+	}
+	return &stmt{conn: c, query: parsedSQL, numArgs: len(args), execOptions: execOptions, statementInfo: info, parsedStatement: parsedStatement}, nil
 }
 
 // Adds any statement or transaction timeout to the given context. The deadline of the returned
@@ -1024,6 +1029,11 @@ func (c *conn) querySingle(ctx context.Context, query string, isPartOfMultiState
 		// statement is visible to the next statement in the SQL string.
 		execOptions.DirectExecuteQuery = true
 	}
+	statementInfo := c.parser.DetectStatementType(query)
+	return c.queryParsed(ctx, query, clientStmt, statementInfo, execOptions, args)
+}
+
+func (c *conn) queryParsed(ctx context.Context, query string, clientStmt parser.ParsedStatement, statementInfo *parser.StatementInfo, execOptions *ExecOptions, args []driver.NamedValue) (driver.Rows, error) {
 	if clientStmt != nil {
 		execStmt, err := createExecutableStatement(clientStmt)
 		if err != nil {
@@ -1031,11 +1041,10 @@ func (c *conn) querySingle(ctx context.Context, query string, isPartOfMultiState
 		}
 		return execStmt.queryContext(ctx, c, execOptions)
 	}
-
-	return c.queryContext(ctx, query, execOptions, args)
+	return c.queryContext(ctx, query, statementInfo, execOptions, args)
 }
 
-func (c *conn) queryContext(ctx context.Context, query string, execOptions *ExecOptions, args []driver.NamedValue) (returnedRows driver.Rows, returnedErr error) {
+func (c *conn) queryContext(ctx context.Context, query string, statementInfo *parser.StatementInfo, execOptions *ExecOptions, args []driver.NamedValue) (returnedRows driver.Rows, returnedErr error) {
 	ctx, cancelCause := context.WithCancelCause(ctx)
 	cancel := func() {
 		cancelCause(nil)
@@ -1058,7 +1067,6 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions *Exec
 	if err != nil {
 		return nil, err
 	}
-	statementInfo := c.parser.DetectStatementType(query)
 
 	// TODO: Refactor queryContext and execContext into one unified method.
 	// DDL statements are not supported in QueryContext so use the execContext method for the execution.
@@ -1068,7 +1076,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions *Exec
 	// DML statements that should use a Partitioned DML transaction should also be re-routed to execContext.
 	shouldUsePDML := !c.inTransaction() && c.AutocommitDMLMode() == PartitionedNonAtomic && isPlainDml
 	if statementInfo.StatementType == parser.StatementTypeDdl || shouldUseDmlBatch || shouldUsePDML {
-		res, err := c.execContext(ctx, query, execOptions, args)
+		res, err := c.execContext(ctx, query, statementInfo, execOptions, args)
 		if err != nil {
 			return nil, err
 		}
@@ -1088,7 +1096,7 @@ func (c *conn) queryContext(ctx context.Context, query string, execOptions *Exec
 		} else if execOptions.PartitionedQueryOptions.PartitionQuery {
 			return nil, spanner.ToSpannerError(status.Errorf(codes.FailedPrecondition, "PartitionQuery is only supported in batch read-only transactions"))
 		} else if execOptions.PartitionedQueryOptions.AutoPartitionQuery {
-			return c.executeAutoPartitionedQuery(ctx, cancel, query, execOptions, args)
+			return c.executeAutoPartitionedQuery(ctx, cancel, query, statementInfo, execOptions, args)
 		} else {
 			// The statement was either detected as being a query, or potentially not recognized at all.
 			// In that case, just default to using a single-use read-only transaction and let Spanner
@@ -1182,6 +1190,11 @@ func (c *conn) execSingle(ctx context.Context, query string, args []driver.Named
 	if err != nil {
 		return nil, err
 	}
+	statementInfo := c.parser.DetectStatementType(query)
+	return c.execParsed(ctx, query, stmt, statementInfo, execOptions, args)
+}
+
+func (c *conn) execParsed(ctx context.Context, query string, stmt parser.ParsedStatement, statementInfo *parser.StatementInfo, execOptions *ExecOptions, args []driver.NamedValue) (driver.Result, error) {
 	if stmt != nil {
 		execStmt, err := createExecutableStatement(stmt)
 		if err != nil {
@@ -1189,10 +1202,10 @@ func (c *conn) execSingle(ctx context.Context, query string, args []driver.Named
 		}
 		return execStmt.execContext(ctx, c, execOptions)
 	}
-	return c.execContext(ctx, query, execOptions, args)
+	return c.execContext(ctx, query, statementInfo, execOptions, args)
 }
 
-func (c *conn) execContext(ctx context.Context, query string, execOptions *ExecOptions, args []driver.NamedValue) (returnedResult driver.Result, returnedErr error) {
+func (c *conn) execContext(ctx context.Context, query string, statementInfo *parser.StatementInfo, execOptions *ExecOptions, args []driver.NamedValue) (returnedResult driver.Result, returnedErr error) {
 	// Add the statement/transaction deadline to the context.
 	ctx, cancel, err := c.addStatementAndTransactionTimeout(ctx)
 	if err != nil {
@@ -1202,7 +1215,6 @@ func (c *conn) execContext(ctx context.Context, query string, execOptions *ExecO
 	// Clear the commit timestamp of this connection before we execute the statement.
 	c.clearCommitResponse()
 
-	statementInfo := c.parser.DetectStatementType(query)
 	// Use admin API if DDL statement is provided.
 	if statementInfo.StatementType == parser.StatementTypeDdl {
 		// Spanner does not support DDL in transactions, and although it is technically possible to execute DDL
@@ -1709,7 +1721,7 @@ func queryInSingleUse(ctx context.Context, c *spanner.Client, statement spanner.
 	return c.Single().WithTimestampBound(tb).QueryWithOptions(ctx, statement, options.QueryOptions)
 }
 
-func (c *conn) executeAutoPartitionedQuery(ctx context.Context, cancel context.CancelFunc, query string, execOptions *ExecOptions, args []driver.NamedValue) (returnedRows driver.Rows, returnedErr error) {
+func (c *conn) executeAutoPartitionedQuery(ctx context.Context, cancel context.CancelFunc, query string, statementInfo *parser.StatementInfo, execOptions *ExecOptions, args []driver.NamedValue) (returnedRows driver.Rows, returnedErr error) {
 	// The cancel() function is called by the returned Rows object when it is closed.
 	// However, if an error is returned instead of a Rows instance, we need to cancel
 	// the context when we return from this function.
@@ -1722,7 +1734,7 @@ func (c *conn) executeAutoPartitionedQuery(ctx context.Context, cancel context.C
 	if err != nil {
 		return nil, err
 	}
-	r, err := c.queryContext(ctx, query, execOptions, args)
+	r, err := c.queryContext(ctx, query, statementInfo, execOptions, args)
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, err

--- a/integration_test.go
+++ b/integration_test.go
@@ -307,7 +307,7 @@ func TestAutoConfigEmulatorPostgreSql(t *testing.T) {
 
 	ctx := context.Background()
 	for range 2 {
-		db, err := sql.Open("spanner", "projects/emulator-project/instances/test-instance/databases/test-database;autoConfigEmulator=true;dialect=postgresql")
+		db, err := sql.Open("spanner", "projects/emulator-project/instances/test-instance/databases/test-database-pg;autoConfigEmulator=true;dialect=postgresql")
 		if err != nil {
 			t.Fatalf("could not connect to emulator: %v", err)
 		}

--- a/stmt.go
+++ b/stmt.go
@@ -44,11 +44,12 @@ var _ driver.NamedValueChecker = &stmt{}
 var nullValue = structpb.NewNullValue()
 
 type stmt struct {
-	conn          *conn
-	numArgs       int
-	query         string
-	statementType parser.StatementType
-	execOptions   *ExecOptions
+	conn            *conn
+	numArgs         int
+	query           string
+	statementInfo   *parser.StatementInfo
+	parsedStatement parser.ParsedStatement
+	execOptions     *ExecOptions
 }
 
 func (s *stmt) Close() error {
@@ -64,7 +65,7 @@ func (s *stmt) Exec(_ []driver.Value) (driver.Result, error) {
 }
 
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	return s.conn.execContext(ctx, s.query, s.execOptions, args)
+	return s.conn.execParsed(ctx, s.query, s.parsedStatement, s.statementInfo, s.execOptions, args)
 }
 
 func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
@@ -72,7 +73,7 @@ func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
 }
 
 func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	return s.conn.queryContext(ctx, s.query, s.execOptions, args)
+	return s.conn.queryParsed(ctx, s.query, s.parsedStatement, s.statementInfo, s.execOptions, args)
 }
 
 func (s *stmt) CheckNamedValue(value *driver.NamedValue) error {


### PR DESCRIPTION
Client-side statements like SET and SHOW can now also be used as prepared statements.

This feature is used by gorm for all statements if prepared statements have been enabled for a connector.