### PR TITLE
chore: improve the search algorithm for gRPC binary

### DIFF
--- a/spannerlib/grpc-server/build-executables.sh
+++ b/spannerlib/grpc-server/build-executables.sh
@@ -1,17 +1,17 @@
 # Builds the gRPC server binary for darwin/arm64, linux/x64, and windows/x64.
 # The binaries are stored in the following files:
-# binaries/osx-arm64/grpc_server
-# binaries/linux-x64/grpc_server
-# binaries/win-x64/grpc_server.exe
+# binaries/osx-arm64/spannerlib_grpc_server
+# binaries/linux-x64/spannerlib_grpc_server
+# binaries/win-x64/spannerlib_grpc_server.exe
 
 mkdir -p binaries/osx-arm64
-GOOS=darwin GOARCH=arm64 go build -o binaries/osx-arm64/grpc_server server.go
-chmod +x binaries/osx-arm64/grpc_server
+GOOS=darwin GOARCH=arm64 go build -o binaries/osx-arm64/spannerlib_grpc_server server.go
+chmod +x binaries/osx-arm64/spannerlib_grpc_server
 
 mkdir -p binaries/linux-x64
-GOOS=linux GOARCH=amd64 go build -o binaries/linux-x64/grpc_server server.go
-chmod +x binaries/linux-x64/grpc_server
+GOOS=linux GOARCH=amd64 go build -o binaries/linux-x64/spannerlib_grpc_server server.go
+chmod +x binaries/linux-x64/spannerlib_grpc_server
 
 mkdir -p binaries/win-x64
-GOOS=windows GOARCH=amd64 go build -o binaries/win-x64/grpc_server.exe server.go
-chmod +x binaries/win-x64/grpc_server.exe
+GOOS=windows GOARCH=amd64 go build -o binaries/win-x64/spannerlib_grpc_server.exe server.go
+chmod +x binaries/win-x64/spannerlib_grpc_server.exe

--- a/spannerlib/wrappers/spannerlib-dotnet/build-grpc-server.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/build-grpc-server.sh
@@ -6,13 +6,13 @@ cd ../../grpc-server || exit 1
 cd ../wrappers/spannerlib-dotnet || exit 1
 
 mkdir -p spannerlib-dotnet-grpc-server/binaries/any
-rm spannerlib-dotnet-grpc-server/binaries/any/grpc_server 2> /dev/null
+rm spannerlib-dotnet-grpc-server/binaries/any/spannerlib_grpc_server 2> /dev/null
 
 mkdir -p spannerlib-dotnet-grpc-server/binaries/osx-arm64
-cp ../../grpc-server/binaries/osx-arm64/grpc_server spannerlib-dotnet-grpc-server/binaries/osx-arm64/grpc_server
+cp ../../grpc-server/binaries/osx-arm64/spannerlib_grpc_server spannerlib-dotnet-grpc-server/binaries/osx-arm64/spannerlib_grpc_server
 
 mkdir -p spannerlib-dotnet-grpc-server/binaries/linux-x64
-cp ../../grpc-server/binaries/linux-x64/grpc_server spannerlib-dotnet-grpc-server/binaries/linux-x64/grpc_server
+cp ../../grpc-server/binaries/linux-x64/spannerlib_grpc_server spannerlib-dotnet-grpc-server/binaries/linux-x64/spannerlib_grpc_server
 
 mkdir -p spannerlib-dotnet-grpc-server/binaries/win-x64
-cp ../../grpc-server/binaries/win-x64/grpc_server.exe spannerlib-dotnet-grpc-server/binaries/win-x64/grpc_server.exe
+cp ../../grpc-server/binaries/win-x64/spannerlib_grpc_server.exe spannerlib-dotnet-grpc-server/binaries/win-x64/spannerlib_grpc_server.exe

--- a/spannerlib/wrappers/spannerlib-dotnet/publish.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/publish.sh
@@ -3,21 +3,10 @@
 
 # NUGET_API_KEY=secret
 
-VERSION=$(date -u +"1.0.0-alpha.%Y%m%d%H%M%S")
-
 # Update all package references to the new (generated) version.
-# Note that sed works slightly differently on Mac than on Linux/Windows,
-# which is why we have two different versions below.
-echo "Publishing as version $VERSION"
-if [ "$RUNNER_OS" == "macOS" ] || [ "$(uname)" == "Darwin" ]; then
-  find ./ -type f -name "*.csproj" -exec sed -i "" "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" {} \;
-  find ./ -type f -name "*.csproj" -exec sed -i "" "s|<PackageReference Include=\(\"Alpha.Google.Cloud.SpannerLib.*\"\) Version=\".*\" />|<PackageReference Include=\1 Version=\"$VERSION\" />|g" {} \;
-else
-  find ./ -type f -name "*.csproj" -exec sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" {} \;
-  find ./ -type f -name "*.csproj" -exec sed -i "s|<PackageReference Include=\(\"Alpha.Google.Cloud.SpannerLib.*\"\) Version=\".*\" />|<PackageReference Include=\1 Version=\"$VERSION\" />|g" {} \;
-fi
+./update-versions.sh
 
-# Build all components
+# Build all components.
 ./build.sh
 
 # Remove existing packages to ensure that only the packages that are built in the next step will be pushed to nuget.

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/spannerlib-dotnet-grpc-impl.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/spannerlib-dotnet-grpc-impl.csproj
@@ -6,13 +6,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
     <PackageId>Alpha.Google.Cloud.SpannerLib.GrpcImpl</PackageId>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
     <Authors>Google</Authors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" Version="5.0.0.1" />
-    <PackageReference Include="Alpha.Google.Cloud.SpannerLib.GrpcServer" Version="1.0.0-alpha.20251027150914" />
+    <PackageReference Include="Alpha.Google.Cloud.SpannerLib.GrpcServer" Version="1.0.0-alpha.20260119112406" />
   </ItemGroup>
 
   <ItemGroup>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/spannerlib-dotnet-grpc-server.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/spannerlib-dotnet-grpc-server.csproj
@@ -8,7 +8,7 @@
     <PackageId>Alpha.Google.Cloud.SpannerLib.GrpcServer</PackageId>
     <Title>SpannerLib Grpc Server</Title>
     <Authors>Google</Authors>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-v1/spannerlib-dotnet-grpc-v1.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-v1/spannerlib-dotnet-grpc-v1.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
     <PackageId>Alpha.Google.Cloud.SpannerLib.Grpc.V1</PackageId>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
     <Authors>Google</Authors>
   </PropertyGroup>
   <ItemGroup>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/spannerlib-dotnet-mockserver.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-mockserver/spannerlib-dotnet-mockserver.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Alpha.Google.Cloud.SpannerLib.MockServer</PackageId>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
     <Authors>Google</Authors>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native-impl/spannerlib-dotnet-native-impl.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native-impl/spannerlib-dotnet-native-impl.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
     <PackageId>Alpha.Google.Cloud.SpannerLib.NativeImpl</PackageId>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
     <Authors>Google</Authors>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" Version="5.0.0.1" />
-    <PackageReference Include="Alpha.Google.Cloud.SpannerLib.Native" Version="1.0.0-alpha.20251027150914" />
+    <PackageReference Include="Alpha.Google.Cloud.SpannerLib.Native" Version="1.0.0-alpha.20260119112406" />
   </ItemGroup>
 
 </Project>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native/spannerlib-dotnet-native.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native/spannerlib-dotnet-native.csproj
@@ -9,7 +9,7 @@
     <PackageId>Alpha.Google.Cloud.SpannerLib.Native</PackageId>
     <Title>.NET wrapper for the native SpannerLib shared library</Title>
     <Authors>Google</Authors>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/spannerlib-dotnet.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/spannerlib-dotnet.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
     <PackageId>Alpha.Google.Cloud.SpannerLib</PackageId>
-    <Version>1.0.0-alpha.20251027150914</Version>
+    <Version>1.0.0-alpha.20260119112406</Version>
     <Authors>Google</Authors>
   </PropertyGroup>
 

--- a/spannerlib/wrappers/spannerlib-dotnet/update-versions.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/update-versions.sh
@@ -1,0 +1,13 @@
+VERSION=$(date -u +"1.0.0-alpha.%Y%m%d%H%M%S")
+
+# Update all package references to the new (generated) version.
+# Note that sed works slightly differently on Mac than on Linux/Windows,
+# which is why we have two different versions below.
+echo "Building as version $VERSION"
+if [ "$RUNNER_OS" == "macOS" ] || [ "$(uname)" == "Darwin" ]; then
+  find ./ -type f -name "*.csproj" -exec sed -i "" "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" {} \;
+  find ./ -type f -name "*.csproj" -exec sed -i "" "s|<PackageReference Include=\(\"Alpha.Google.Cloud.SpannerLib.*\"\) Version=\".*\" />|<PackageReference Include=\1 Version=\"$VERSION\" />|g" {} \;
+else
+  find ./ -type f -name "*.csproj" -exec sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" {} \;
+  find ./ -type f -name "*.csproj" -exec sed -i "s|<PackageReference Include=\(\"Alpha.Google.Cloud.SpannerLib.*\"\) Version=\".*\" />|<PackageReference Include=\1 Version=\"$VERSION\" />|g" {} \;
+fi


### PR DESCRIPTION
Improve the search algorithm for finding the gRPC server binary in SpannerLib. The original algorithm only looked in the current directory. This did not work when running a .NET application from the command line using `dotnet run`.

This PR also:
- Updates the 'snapshot' version numbers of all the .NET wrapper libraries, as they had gotten out of sync.
- Renames the gRPC binary file name from `grpc_server` to `spannerlib_grpc_server`. This makes it easier for customers to understand what the binary is doing if they see it in their list of running processes.
- This change has been tested with the samples for the ADO.NET driver. Once this has been released, the automated tests for the ADO.NET driver will be extended with an additional test that verifies that the samples can be executed with a simple `dotnet run ...` command.