### PR TITLE
chore: support linux-arm64 for SpannerLib .NET gRPC

### DIFF
--- a/spannerlib/grpc-server/build-executables.sh
+++ b/spannerlib/grpc-server/build-executables.sh
@@ -1,17 +1,31 @@
+#!/bin/bash
+
 # Builds the gRPC server binary for darwin/arm64, linux/x64, and windows/x64.
 # The binaries are stored in the following files:
 # binaries/osx-arm64/spannerlib_grpc_server
 # binaries/linux-x64/spannerlib_grpc_server
+# binaries/linux-arm64/spannerlib_grpc_server
 # binaries/win-x64/spannerlib_grpc_server.exe
 
-mkdir -p binaries/osx-arm64
-GOOS=darwin GOARCH=arm64 go build -o binaries/osx-arm64/spannerlib_grpc_server server.go
-chmod +x binaries/osx-arm64/spannerlib_grpc_server
+set -e
 
-mkdir -p binaries/linux-x64
-GOOS=linux GOARCH=amd64 go build -o binaries/linux-x64/spannerlib_grpc_server server.go
-chmod +x binaries/linux-x64/spannerlib_grpc_server
+build_target() {
+  local goos=$1
+  local goarch=$2
+  local dir_os=$3
+  local dir_arch=$4
+  local ext=${5:-}
 
-mkdir -p binaries/win-x64
-GOOS=windows GOARCH=amd64 go build -o binaries/win-x64/spannerlib_grpc_server.exe server.go
-chmod +x binaries/win-x64/spannerlib_grpc_server.exe
+  local dir="binaries/${dir_os}-${dir_arch}"
+  local output="${dir}/spannerlib_grpc_server${ext}"
+
+  echo "Building for ${goos}/${goarch}..."
+  mkdir -p "${dir}"
+  GOOS=${goos} GOARCH=${goarch} go build -o "${output}" server.go
+  chmod +x "${output}"
+}
+
+build_target "darwin" "arm64" "osx" "arm64"
+build_target "linux" "amd64" "linux" "x64"
+build_target "linux" "arm64" "linux" "arm64"
+build_target "windows" "amd64" "win" "x64" ".exe"

--- a/spannerlib/wrappers/spannerlib-dotnet/build-grpc-server.sh
+++ b/spannerlib/wrappers/spannerlib-dotnet/build-grpc-server.sh
@@ -5,14 +5,21 @@ cd ../../grpc-server || exit 1
 ./build-executables.sh
 cd ../wrappers/spannerlib-dotnet || exit 1
 
+copy_binary() {
+  local platform=$1 # e.g., osx-arm64
+  local ext=${2:-}
+  local src_dir="../../grpc-server/binaries/${platform}"
+  local dest_dir="spannerlib-dotnet-grpc-server/binaries/${platform}"
+  local filename="spannerlib_grpc_server${ext}"
+
+  mkdir -p "${dest_dir}"
+  cp "${src_dir}/${filename}" "${dest_dir}/${filename}"
+}
+
 mkdir -p spannerlib-dotnet-grpc-server/binaries/any
 rm spannerlib-dotnet-grpc-server/binaries/any/spannerlib_grpc_server 2> /dev/null
 
-mkdir -p spannerlib-dotnet-grpc-server/binaries/osx-arm64
-cp ../../grpc-server/binaries/osx-arm64/spannerlib_grpc_server spannerlib-dotnet-grpc-server/binaries/osx-arm64/spannerlib_grpc_server
-
-mkdir -p spannerlib-dotnet-grpc-server/binaries/linux-x64
-cp ../../grpc-server/binaries/linux-x64/spannerlib_grpc_server spannerlib-dotnet-grpc-server/binaries/linux-x64/spannerlib_grpc_server
-
-mkdir -p spannerlib-dotnet-grpc-server/binaries/win-x64
-cp ../../grpc-server/binaries/win-x64/spannerlib_grpc_server.exe spannerlib-dotnet-grpc-server/binaries/win-x64/spannerlib_grpc_server.exe
+copy_binary "osx-arm64"
+copy_binary "linux-x64"
+copy_binary "linux-arm64"
+copy_binary "win-x64" ".exe"

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
@@ -136,6 +136,9 @@ public class Server : IDisposable
                 case Architecture.X64:
                     fileName = $"runtimes/linux-x64/native/{BaseFileName}";
                     break;
+                case Architecture.Arm64:
+                    fileName = $"runtimes/linux-arm64/native/{BaseFileName}";
+                    break;
             }
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/spannerlib-dotnet-grpc-server.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/spannerlib-dotnet-grpc-server.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <None Include="binaries/any/*" Pack="true" PackagePath="runtimes/any/native/" />
     <None Include="binaries/linux-x64/*" Pack="true" PackagePath="runtimes/linux-x64/native/" />
+    <None Include="binaries/linux-arm64/*" Pack="true" PackagePath="runtimes/linux-arm64/native/" />
     <None Include="binaries/osx-arm64/*" Pack="true" PackagePath="runtimes/osx-arm64/native/" />
     <None Include="binaries/win-x64/*" Pack="true" PackagePath="runtimes/win-x64/native/" />
   </ItemGroup>


### PR DESCRIPTION
Adds support for using the .NET SpannerLib wrapper on linux-arm64.