### PR TITLE
feat: add database_dialect property

### DIFF
--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -1924,6 +1924,42 @@ func TestDmlBatchReturnsBatchUpdateCountsOutsideTransaction(t *testing.T) {
 	}
 }
 
+func TestDatabaseDialectProperty_PostgreSQL(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnectionWithParamsAndDialect(t, "", databasepb.DatabaseDialect_POSTGRESQL)
+	defer teardown()
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	verifyConnectionPropertyValue(t, conn, "database_dialect", "POSTGRESQL")
+	// Verify that 'dialect' property is NOT updated and remains empty/unspecified.
+	verifyConnectionPropertyValue(t, conn, "dialect", "")
+	verifySetFails(t, conn, "database_dialect", "'GOOGLE_STANDARD_SQL'")
+}
+
+func TestDatabaseDialectProperty_GoogleSQL(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnectionWithParamsAndDialect(t, "", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+	defer teardown()
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	verifyConnectionPropertyValue(t, conn, "database_dialect", "GOOGLE_STANDARD_SQL")
+	verifySetFails(t, conn, "database_dialect", "'POSTGRESQL'")
+}
+
 func verifyConnectionPropertyValue[T comparable](t *testing.T, c *sql.Conn, name string, value T) {
 	ctx := context.Background()
 	row := c.QueryRowContext(ctx, getShowStatement(c)+name)

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -721,6 +721,14 @@ var propertyCommitResponse = createReadOnlyConnectionProperty(
 	nil,
 	connectionstate.ContextUser,
 )
+var propertyDatabaseDialect = createReadOnlyConnectionProperty(
+	"database_dialect",
+	"The dialect of the database that the connection is connected to. This property is read-only and is automatically determined at startup.",
+	databasepb.DatabaseDialect_DATABASE_DIALECT_UNSPECIFIED,
+	false,
+	nil,
+	connectionstate.ContextUser,
+)
 
 func createReadOnlyConnectionProperty[T comparable](name, description string, defaultValue T, hasDefaultValue bool, validValues []T, context connectionstate.Context) *connectionstate.TypedConnectionProperty[T] {
 	converter := connectionstate.CreateReadOnlyConverter[T](name)

--- a/driver.go
+++ b/driver.go
@@ -841,7 +841,6 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 	}
 
 	if err := c.increaseConnCount(ctx, databaseName, opts); err != nil {
-
 		return nil, err
 	}
 
@@ -855,7 +854,6 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 			connectionStateType = connectionstate.TypeNonTransactional
 		}
 	}
-
 	connection := &conn{
 		parser:                       c.parser,
 		connector:                    c,
@@ -871,11 +869,9 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 		execSingleDMLTransactional:   execInNewRWTransaction,
 		execSingleDMLPartitioned:     execAsPartitionedDML,
 	}
-
 	// Initialize the session.
 	_ = connection.ResetSession(context.Background())
 	return connection, nil
-
 }
 
 func addStateFromConnectorConfig(c *connector, values map[string]connectionstate.ConnectionPropertyValue) {

--- a/driver.go
+++ b/driver.go
@@ -825,7 +825,10 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 		c.connectorConfig.Project,
 		c.connectorConfig.Instance,
 		c.connectorConfig.Database)
-	if value, ok := c.initialPropertyValues[propertyConnectTimeout.Key()]; ok {
+	c.clientMu.Lock()
+	value, ok := c.initialPropertyValues[propertyConnectTimeout.Key()]
+	c.clientMu.Unlock()
+	if ok {
 		if timeout, err := value.GetValue(); err == nil {
 			if duration, ok := timeout.(time.Duration); ok {
 				var cancel context.CancelFunc
@@ -838,6 +841,7 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 	}
 
 	if err := c.increaseConnCount(ctx, databaseName, opts); err != nil {
+
 		return nil, err
 	}
 
@@ -851,6 +855,7 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 			connectionStateType = connectionstate.TypeNonTransactional
 		}
 	}
+
 	connection := &conn{
 		parser:                       c.parser,
 		connector:                    c,
@@ -866,9 +871,11 @@ func openDriverConn(ctx context.Context, c *connector) (driver.Conn, error) {
 		execSingleDMLTransactional:   execInNewRWTransaction,
 		execSingleDMLPartitioned:     execAsPartitionedDML,
 	}
+
 	// Initialize the session.
 	_ = connection.ResetSession(context.Background())
 	return connection, nil
+
 }
 
 func addStateFromConnectorConfig(c *connector, values map[string]connectionstate.ConnectionPropertyValue) {
@@ -926,6 +933,7 @@ func (c *connector) increaseConnCount(ctx context.Context, databaseName string, 
 				closeClient()
 				return err
 			}
+			updateConnectionPropertyValueIfNotExists(propertyDatabaseDialect, c.initialPropertyValues, dialect)
 		}
 
 		c.logger.Log(ctx, LevelNotice, "creating Spanner Admin client")


### PR DESCRIPTION
Adds a database_dialect property that shows the dialect of the current database. This property is automatically determined at startup and cannot be manually modified. This is different from the 'dialect' connection property, which can be set manually, and is used to determine the dialect that should be used for new databases that are created from this connection. The latter is primarily used in combination with the auto_config_emulator property.

Fixes #784