### PR TITLE
build: configure renovate for auto-merge

### DIFF
--- a/.github/workflows/tidy-bot-pr.yml
+++ b/.github/workflows/tidy-bot-pr.yml
@@ -1,0 +1,65 @@
+name: Tidy Bot PRs
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+jobs:
+  tidy:
+    # Only run for PRs created by Renovate or Dependabot
+    if: |
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # We checkout the head branch of the PR to apply changes to it
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # By default we use GITHUB_TOKEN.
+          # Note: Pushing with GITHUB_TOKEN will not trigger subsequent workflow runs (like tests) on the new commit.
+          # If tests are required to pass on the latest commit, configure a Personal Access Token (PAT) named BOT_PAT.
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          # Using Go version from root go.mod or latest stable
+          go-version: '1.26.x'
+
+      - name: Run go mod tidy on all modules
+        run: |
+          find . -name "go.mod" -not -path "*/.*" | while read -r gomod; do
+            dir=$(dirname "$gomod")
+            echo "Tidying module in $dir"
+            (cd "$dir" && go mod tidy)
+          done
+
+      - name: Commit and Push changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Changes detected, committing..."
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "chore: run go mod tidy"
+            git push
+          else
+            echo "No changes detected."
+          fi
+
+      - name: Auto-Approve Minor/Patch PRs
+        if: |
+          contains(github.event.pull_request.head.ref, 'minor-and-patch') &&
+          secrets.BOT_PAT != ''
+        run: |
+          echo "Approving PR..."
+          gh pr review ${{ github.event.pull_request.html_url }} --approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,14 @@
     "gomodTidy"
   ],
   "commitMessageAction": "update",
-  "groupName": "all dependencies"
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "minor and patch dependencies",
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Configure renovate to auto-merge pull requests as long as the dependency updates are only minor or patch version updates. Also fixes the missing 'go mod tidy' executions on subfolders.