### PR TITLE
feat: support case-insensitive query parameter matching

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -110,7 +110,18 @@ func prepareSpannerStmt(state *connectionstate.ConnectionState, parser *parser.S
 		}
 		if name != "" {
 			found := false
-			if len(namesToIndex) > 0 {
+			if _, ok := namesToIndex[name]; ok {
+				found = true
+			}
+			if !found {
+				for _, queryName := range names {
+					if queryName == name {
+						found = true
+						break
+					}
+				}
+			}
+			if !found && len(namesToIndex) > 0 {
 				for queryName := range namesToIndex {
 					if strings.EqualFold(queryName, name) {
 						name = queryName

--- a/stmt.go
+++ b/stmt.go
@@ -19,6 +19,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"cloud.google.com/go/spanner"
 	"github.com/googleapis/go-sql-spanner/connectionstate"
@@ -106,6 +107,26 @@ func prepareSpannerStmt(state *connectionstate.ConnectionState, parser *parser.S
 		if sa, ok := args[i].Value.(SpannerNamedArg); ok {
 			name = sa.NameInQuery
 			value = sa.Value
+		}
+		if name != "" {
+			found := false
+			if len(namesToIndex) > 0 {
+				for queryName := range namesToIndex {
+					if strings.EqualFold(queryName, name) {
+						name = queryName
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				for _, queryName := range names {
+					if strings.EqualFold(queryName, name) {
+						name = queryName
+						break
+					}
+				}
+			}
 		}
 		if name == "" && len(names) > i {
 			name = names[i]

--- a/stmt_with_mockserver_test.go
+++ b/stmt_with_mockserver_test.go
@@ -535,6 +535,18 @@ func TestNamedParametersWithGoogleSQL(t *testing.T) {
 			wantParams: map[string]string{"id": "1", "value": "One"},
 		},
 		{
+			name:       "case_insensitive",
+			params:     []any{sql.Named("ID", 1), sql.Named("Value", "One")},
+			input:      "insert into my_table (id, value) values (@id, @value)",
+			wantParams: map[string]string{"id": "1", "value": "One"},
+		},
+		{
+			name:       "case_insensitive_2",
+			params:     []any{sql.Named("id", 1), sql.Named("value", "One")},
+			input:      "insert into my_table (id, value) values (@ID, @VALUE)",
+			wantParams: map[string]string{"ID": "1", "VALUE": "One"},
+		},
+		{
 			name:       "input_out_of_order",
 			params:     []any{sql.Named("value", "One"), sql.Named("id", 1)},
 			input:      "insert into my_table (id, value) values (@id, @value)",
@@ -736,6 +748,20 @@ func TestNamedParametersWithPG(t *testing.T) {
 			params:     []any{sql.Named("id", 1), sql.Named("value", "One")},
 			input:      "insert into my_table (id, initial_value, current_value, generation) values (@id, @value, @value, @id)",
 			wantSQL:    "insert into my_table (id, initial_value, current_value, generation) values ($1, $2, $2, $1)",
+			wantParams: map[string]string{"p1": "1", "p2": "One"},
+		},
+		{
+			name:       "case_insensitive",
+			params:     []any{sql.Named("ID", 1), sql.Named("Value", "One")},
+			input:      "insert into my_table (id, value) values (@id, @value)",
+			wantSQL:    "insert into my_table (id, value) values ($1, $2)",
+			wantParams: map[string]string{"p1": "1", "p2": "One"},
+		},
+		{
+			name:       "case_insensitive_2",
+			params:     []any{sql.Named("id", 1), sql.Named("value", "One")},
+			input:      "insert into my_table (id, value) values (@ID, @VALUE)",
+			wantSQL:    "insert into my_table (id, value) values ($1, $2)",
 			wantParams: map[string]string{"p1": "1", "p2": "One"},
 		},
 		{

--- a/stmt_with_mockserver_test.go
+++ b/stmt_with_mockserver_test.go
@@ -547,6 +547,12 @@ func TestNamedParametersWithGoogleSQL(t *testing.T) {
 			wantParams: map[string]string{"ID": "1", "VALUE": "One"},
 		},
 		{
+			name:       "case_insensitive_exact_match_priority",
+			params:     []any{sql.Named("id", 1), sql.Named("ID", 2)},
+			input:      "insert into my_table (id, value) values (@id, @ID)",
+			wantParams: map[string]string{"id": "1", "ID": "2"},
+		},
+		{
 			name:       "input_out_of_order",
 			params:     []any{sql.Named("value", "One"), sql.Named("id", 1)},
 			input:      "insert into my_table (id, value) values (@id, @value)",


### PR DESCRIPTION
Normalize bound parameter names case-insensitively against the parameter names parsed from the SQL statement. This allows using any case in database/sql named arguments (e.g. sql.Named('id', ...)) to match case-insensitive query parameters in the statement (e.g. @ID).

Fixes #594