### PR TITLE
fix(test): resolve flakiness in TestStatementTimeout

### DIFF
--- a/stmt_with_mockserver_test.go
+++ b/stmt_with_mockserver_test.go
@@ -243,8 +243,9 @@ func TestStatementTimeout(t *testing.T) {
 	defer teardown()
 	ctx := context.Background()
 
-	// The database/sql driver uses ExecuteStreamingSql for all statements.
+	// The database/sql driver uses ExecuteStreamingSql for queries and ExecuteSql for DMLs.
 	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 50 * time.Millisecond})
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 50 * time.Millisecond})
 
 	_, err := db.ExecContext(ctx, testutil.UpdateBarSetFoo)
 	if g, w := spanner.ErrCode(err), codes.DeadlineExceeded; g != w {


### PR DESCRIPTION
Resolves the flakiness in TestStatementTimeout by setting simulated execution time for MethodExecuteSql. DML statements use ExecuteSql under the hood, so without simulated delay they could execute in less than 1ms (returning OK instead of DeadlineExceeded).

Fixes #698