### PR TITLE
fix(ruby-wrapper): resolve flakiness on Windows and path warning

### DIFF
--- a/spannerlib/wrappers/spannerlib-ruby/spannerlib-ruby.gemspec
+++ b/spannerlib/wrappers/spannerlib-ruby/spannerlib-ruby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     files = []
     # prefer git-tracked files when available (local dev), but also pick up built files present on disk (CI)
-    files += `git ls-files -z`.split("\x0") if system("git rev-parse --is-inside-work-tree > /dev/null 2>&1")
+    files += `git ls-files -z`.split("\x0") if system("git rev-parse --is-inside-work-tree > #{File::NULL} 2>&1")
 
     # include any built native libs (CI places them under lib/spannerlib/)
     files += Dir.glob("lib/spannerlib/**/*").select { |f| File.file?(f) }

--- a/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
+++ b/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
@@ -98,9 +98,9 @@ describe "Connection" do
         unless content.empty?
           port = content.to_i
           begin
-            Socket.tcp("127.0.0.1", port, connect_timeout: 0.1) { |s| s.close }
+            Socket.tcp("127.0.0.1", port, connect_timeout: 0.1) { nil }
             return port
-          rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
+          rescue SystemCallError
             # Server not yet fully listening
           end
         end

--- a/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
+++ b/spannerlib/wrappers/spannerlib-ruby/spec/spannerlib_ruby_spec.rb
@@ -21,6 +21,7 @@ require "minitest/autorun"
 require "google/cloud/spanner/v1/spanner"
 require "timeout"
 require "tmpdir"
+require "socket"
 
 require_relative "mock_server/statement_result"
 require_relative "../lib/spannerlib/ffi"
@@ -94,7 +95,15 @@ describe "Connection" do
 
       if File.exist?($port_file)
         content = File.read($port_file).strip
-        return content.to_i unless content.empty?
+        unless content.empty?
+          port = content.to_i
+          begin
+            Socket.tcp("127.0.0.1", port, connect_timeout: 0.1) { |s| s.close }
+            return port
+          rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
+            # Server not yet fully listening
+          end
+        end
       end
 
       raise "Mock server exited unexpectedly!" if Process.waitpid($server_pid, Process::WNOHANG)
@@ -170,7 +179,7 @@ describe "Connection" do
   before do
     self.class.ensure_server_running!
     File.binwrite($mock_msg_file, Marshal.dump({}))
-    File.write($mock_req_file, "")
+    File.binwrite($mock_req_file, "")
     @dsn = "127.0.0.1:#{$server_port}/projects/p/instances/i/databases/d?useplaintext=true"
 
     @pool_id = SpannerLib.create_pool(@dsn)


### PR DESCRIPTION
Resolves test flakiness on Windows by:
1. Ensuring the mock server is fully listening and accepting TCP connections before returning the port from wait_for_port.
2. Using File.binwrite instead of File.write to truncate the request log file to avoid text-mode translations.
3. Using File::NULL instead of /dev/null in the gemspec to avoid path-not-found warnings on Windows.

Fixes #678