### PR TITLE
fix(test): resolve flakiness in TestTransactionTimeout tests

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -325,9 +325,9 @@ func TestTransactionTimeout(t *testing.T) {
 	defer teardown()
 	ctx := context.Background()
 
-	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 50 * time.Millisecond})
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 200 * time.Millisecond})
 	tx, _ := db.BeginTx(ctx, &sql.TxOptions{})
-	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=10ms"); err != nil {
+	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=100ms"); err != nil {
 		t.Fatal(err)
 	}
 	_, err := tx.ExecContext(ctx, testutil.UpdateBarSetFoo)
@@ -367,14 +367,14 @@ func TestTransactionTimeoutSecondStatement(t *testing.T) {
 	ctx := context.Background()
 
 	tx, _ := db.BeginTx(ctx, &sql.TxOptions{})
-	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=40ms"); err != nil {
+	if _, err := tx.ExecContext(ctx, "set local transaction_timeout=200ms"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := tx.ExecContext(ctx, testutil.UpdateBarSetFoo); err != nil {
 		t.Fatal(err)
 	}
 
-	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 60 * time.Millisecond})
+	server.TestSpanner.PutExecutionTime(testutil.MethodExecuteStreamingSql, testutil.SimulatedExecutionTime{MinimumExecutionTime: 300 * time.Millisecond})
 	rows, err := tx.QueryContext(ctx, testutil.SelectFooFromBar, ExecOptions{DirectExecuteQuery: true})
 	if rows != nil {
 		_ = rows.Close()


### PR DESCRIPTION
Resolves test flakiness in TestTransactionTimeout and TestTransactionTimeoutSecondStatement by increasing the transaction timeouts and simulated execution delays. Very short timeouts (10ms and 40ms) were susceptible to context cancellations during initial gRPC setup and statement execution on slow or resource-constrained CI runners.

Fixes #635