### PR TITLE
ci: add trust for the macos cross-compiler

### DIFF
--- a/.github/workflows/spanner-lib-tests.yml
+++ b/.github/workflows/spanner-lib-tests.yml
@@ -119,6 +119,7 @@ jobs:
             echo "Windows does not yet support cross compiling"
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew tap SergioBenitez/osxct
+            brew trust SergioBenitez/osxct
             brew install x86_64-unknown-linux-gnu
             brew install mingw-w64
           else

--- a/.github/workflows/spanner-lib-tests.yml
+++ b/.github/workflows/spanner-lib-tests.yml
@@ -118,10 +118,11 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             echo "Windows does not yet support cross compiling"
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew tap SergioBenitez/osxct
-            brew trust SergioBenitez/osxct
+            brew tap MaterializeInc/crosstools
+            brew trust MaterializeInc/crosstools
             brew install x86_64-unknown-linux-gnu
             brew install mingw-w64
+            x86_64-unknown-linux-gnu-gcc --version
           else
             sudo apt-get update
             sudo apt install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
@@ -133,6 +134,14 @@ jobs:
         run: |
           echo "$RUNNER_OS"
           ./build.sh
+        shell: bash
+      - name: Verify compiled binaries
+        # Sanity check: verify that the compiled Linux shared library is a valid 64-bit ELF binary.
+        # This is crucial on macOS to ensure the cross-compiler succeeded and did not fallback
+        # to producing a macOS Mach-O binary.
+        if: matrix.os != 'windows-latest'
+        run: |
+          file spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-native/libraries/linux-x64/spannerlib.so | grep "ELF 64-bit"
         shell: bash
       - name: Restore dependencies
         run: dotnet restore

--- a/spannerlib/shared/build-binaries.sh
+++ b/spannerlib/shared/build-binaries.sh
@@ -58,7 +58,7 @@ if [ -z "$SKIP_MACOS" ]; then
 fi
 
 # --- Linux Builds ---
-if [ -z "$SKIP_LINUX" ]; then
+if [ -z "$SKIP_LINUX" ] || [ -z "$SKIP_LINUX_CROSS_COMPILE" ]; then
     # Linux x64
     # Logic: If we are on Linux, we prefer native build. 
     # If we are NOT on Linux (e.g. Mac), we try cross-compile unless skipped.


### PR DESCRIPTION
Homebrew's new security policy requires third-party formulas to be explicitly trusted.

Fixes https://github.com/googleapis/go-sql-spanner/actions/runs/28150340416/job/83366358398?pr=852