### PR TITLE
test: stabilize flaky workflows and support reusing Spanner emulator

### DIFF
--- a/.github/workflows/build-shared-spanner-lib.yml
+++ b/.github/workflows/build-shared-spanner-lib.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
-        cache: true
+        cache-dependency-path: spannerlib/go.sum
 
     - name: Install Dependencies (Linux)
       if: matrix.target == 'linux'

--- a/.github/workflows/integration-tests-on-emulator.yml
+++ b/.github/workflows/integration-tests-on-emulator.yml
@@ -20,12 +20,12 @@ jobs:
           - 9010:9010
           - 9020:9020
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
-      - name: Checkout code
-        uses: actions/checkout@v7
       - name: Run Go integration tests on emulator
         run: go test -race
         env:

--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
-      - name: Checkout code
-        uses: actions/checkout@v7
       - name: Auth
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/node-spanner-lib-wrapper-unit-tests.yml
+++ b/.github/workflows/node-spanner-lib-wrapper-unit-tests.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.x'
+        cache-dependency-path: spannerlib/go.sum
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/python-spanner-lib-wrapper-system-tests.yml
+++ b/.github/workflows/python-spanner-lib-wrapper-system-tests.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.x'
+        cache-dependency-path: spannerlib/go.sum
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/python-spanner-lib-wrapper-unit-tests.yml
+++ b/.github/workflows/python-spanner-lib-wrapper-unit-tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.26.x'
+        cache-dependency-path: spannerlib/go.sum
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/release-dotnet-native-spanner-lib.yml
+++ b/.github/workflows/release-dotnet-native-spanner-lib.yml
@@ -8,12 +8,13 @@ jobs:
   build-linux-x64:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.26
-      - name: Checkout code
-        uses: actions/checkout@v7
+          cache-dependency-path: spannerlib/go.sum
       - name: Build shared library
         working-directory: spannerlib
         run: go build -o spannerlib.so -buildmode=c-shared shared_lib.go
@@ -33,12 +34,13 @@ jobs:
   build-osx-arm64:
     runs-on: macos-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.26
-      - name: Checkout code
-        uses: actions/checkout@v7
+          cache-dependency-path: spannerlib/go.sum
       - name: Build shared library
         working-directory: spannerlib
         run: go build -o spannerlib.dylib -buildmode=c-shared shared_lib.go

--- a/.github/workflows/release-ruby-wrapper.yml
+++ b/.github/workflows/release-ruby-wrapper.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
+          cache-dependency-path: spannerlib/go.sum
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby-wrapper-tests.yml
+++ b/.github/workflows/ruby-wrapper-tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
+          cache-dependency-path: spannerlib/go.sum
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -11,13 +11,24 @@ jobs:
       matrix:
         go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
+    services:
+      emulator:
+        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        ports:
+          - 9010:9010
+          - 9020:9020
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v7
+          cache-dependency-path: |
+            go.sum
+            examples/go.sum
       - name: Run samples
         working-directory: ./examples
+        env:
+          SPANNER_EMULATOR_HOST: localhost:9010
         run: go test -short

--- a/.github/workflows/snippets.yml
+++ b/.github/workflows/snippets.yml
@@ -12,12 +12,15 @@ jobs:
         go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v7
+          cache-dependency-path: |
+            go.sum
+            snippets/go.sum
       - name: Run snippets
         working-directory: ./snippets
         run: go test -short

--- a/.github/workflows/spanner-lib-tests.yml
+++ b/.github/workflows/spanner-lib-tests.yml
@@ -14,12 +14,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v7
+          cache-dependency-path: spannerlib/go.sum
       - name: Run unit tests
         working-directory: spannerlib
         run: go test ./... -race -short
@@ -45,6 +46,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: spannerlib/go.sum
       - name: Build shared library
         working-directory: spannerlib/shared
         run: go build -o spannerlib.so -buildmode=c-shared shared_lib.go
@@ -111,6 +113,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: spannerlib/go.sum
       # Install compilers for cross-compiling between operating systems.
       - name: Install compilers
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,12 +15,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v7
       - name: Run unit tests
         run: go test -race -short
       - name: Run connection state unit tests
@@ -33,17 +33,22 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
+          cache-dependency-path: |
+            go.sum
+            examples/go.sum
+            snippets/go.sum
+            benchmarks/go.sum
 
       - name: Install tools
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
-
-      - name: Checkout code
-        uses: actions/checkout@v7
 
       - name: vet .
         run: go vet ./...

--- a/examples/emulator/main.go
+++ b/examples/emulator/main.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
 
 	spannerdriver "github.com/googleapis/go-sql-spanner"
 	"github.com/moby/moby/api/types/container"
@@ -39,7 +40,11 @@ func emulator(projectId, instanceId, databaseId string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = emulator.Terminate(context.Background()) }()
+	defer func() {
+		if emulator != nil {
+			_ = emulator.Terminate(context.Background())
+		}
+	}()
 
 	config := spannerdriver.ConnectorConfig{
 		// AutoConfigEmulator instructs the driver to:
@@ -90,6 +95,9 @@ func main() {
 
 // startEmulator starts the Spanner Emulator in a Docker container.
 func startEmulator() (testcontainers.Container, string, error) {
+	if host := os.Getenv("SPANNER_EMULATOR_HOST"); host != "" {
+		return nil, host, nil
+	}
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
 		AlwaysPullImage: true,
@@ -105,17 +113,26 @@ func startEmulator() (testcontainers.Container, string, error) {
 		Started:          true,
 	})
 	if err != nil {
-		return emulator, "", fmt.Errorf("failed to start the emulator: %v", err)
+		return nil, "", fmt.Errorf("failed to start the emulator: %v", err)
 	}
+
+	var success bool
+	defer func() {
+		if !success {
+			_ = emulator.Terminate(ctx)
+		}
+	}()
+
 	host, err := emulator.Host(ctx)
 	if err != nil {
-		return emulator, "", fmt.Errorf("failed to get host: %v", err)
+		return nil, "", fmt.Errorf("failed to get host: %v", err)
 	}
 	mappedPort, err := emulator.MappedPort(ctx, "9010/tcp")
 	if err != nil {
-		return emulator, "", fmt.Errorf("failed to get mapped port: %v", err)
+		return nil, "", fmt.Errorf("failed to get mapped port: %v", err)
 	}
 	port := mappedPort.Port()
 
+	success = true
 	return emulator, fmt.Sprintf("%s:%v", host, port), nil
 }

--- a/examples/emulator_runner.go
+++ b/examples/emulator_runner.go
@@ -52,20 +52,30 @@ func RunSampleOnEmulator(sample func(string, string, string) error, ddlStatement
 
 func RunSampleOnEmulatorWithDialect(sample func(string, string, string) error, dialect databasepb.DatabaseDialect, ddlStatements ...string) {
 	var err error
-	if err = startEmulator(); err != nil {
-		log.Fatalf("failed to start emulator: %v", err)
+	var startedEmulatorSelf bool
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		if err = startEmulator(); err != nil {
+			log.Fatalf("failed to start emulator: %v", err)
+		}
+		startedEmulatorSelf = true
 	}
 	projectId, instanceId, databaseId := "my-project", "my-instance", "my-database"
 	if err = createInstance(projectId, instanceId); err != nil {
-		stopEmulator()
+		if startedEmulatorSelf {
+			stopEmulator()
+		}
 		log.Fatalf("failed to create instance on emulator: %v", err)
 	}
 	if err = createSampleDB(projectId, instanceId, databaseId, dialect, ddlStatements...); err != nil {
-		stopEmulator()
+		if startedEmulatorSelf {
+			stopEmulator()
+		}
 		log.Fatalf("failed to create database on emulator: %v", err)
 	}
 	err = sample(projectId, instanceId, databaseId)
-	stopEmulator()
+	if startedEmulatorSelf {
+		stopEmulator()
+	}
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -77,12 +87,35 @@ func startEmulator() error {
 		return err
 	}
 
+	err := startEmulatorInternal(ctx)
+	if err != nil {
+		_ = os.Unsetenv("SPANNER_EMULATOR_HOST")
+	}
+	return err
+}
+
+func startEmulatorInternal(ctx context.Context) error {
 	// Initialize a Docker client.
 	var err error
 	cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
+	var success bool
+	defer func() {
+		if !success {
+			if cli != nil {
+				if containerId != "" {
+					timeout := 10
+					_ = cli.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeout})
+					containerId = ""
+				}
+				_ = cli.Close()
+				cli = nil
+			}
+		}
+	}()
+
 	// Pull the Spanner Emulator docker image.
 	reader, err := cli.ImagePull(ctx, "gcr.io/cloud-spanner-emulator/emulator", image.PullOptions{})
 	if err != nil {
@@ -107,6 +140,7 @@ func startEmulator() error {
 		return err
 	}
 	containerId = resp.ID
+
 	if err := cli.ContainerStart(ctx, containerId, container.StartOptions{}); err != nil {
 		return err
 	}
@@ -131,7 +165,11 @@ func startEmulator() error {
 	if !portReady {
 		return fmt.Errorf("emulator did not start listening on port 9010 in time")
 	}
-	return waitForGRPC(ctx)
+	if err := waitForGRPC(ctx); err != nil {
+		return err
+	}
+	success = true
+	return nil
 }
 
 func waitForGRPC(ctx context.Context) error {
@@ -154,12 +192,24 @@ func waitForGRPC(ctx context.Context) error {
 }
 
 func createInstance(projectId, instanceId string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	instanceAdmin, err := instance.NewInstanceAdminClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer instanceAdmin.Close()
+
+	inst, err := instanceAdmin.GetInstance(ctx, &instancepb.GetInstanceRequest{
+		Name: fmt.Sprintf("projects/%s/instances/%s", projectId, instanceId),
+	})
+	if err == nil && inst != nil {
+		return nil
+	}
+	if status.Code(err) != codes.NotFound {
+		return fmt.Errorf("failed to check if instance exists: %w", err)
+	}
+
 	op, err := instanceAdmin.CreateInstance(ctx, &instancepb.CreateInstanceRequest{
 		Parent:     fmt.Sprintf("projects/%s", projectId),
 		InstanceId: instanceId,
@@ -180,12 +230,18 @@ func createInstance(projectId, instanceId string) error {
 }
 
 func createSampleDB(projectId, instanceId, databaseId string, dialect databasepb.DatabaseDialect, statements ...string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer databaseAdminClient.Close()
+
+	// Drop the database if it already exists.
+	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId)
+	_ = databaseAdminClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbPath})
+
 	var createStatement string
 	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
 		createStatement = fmt.Sprintf(`CREATE DATABASE "%s"`, databaseId)
@@ -217,4 +273,8 @@ func stopEmulator() {
 	if err := cli.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeout}); err != nil {
 		log.Printf("failed to stop emulator: %v\n", err)
 	}
+	_ = cli.Close()
+	cli = nil
+	containerId = ""
+	_ = os.Unsetenv("SPANNER_EMULATOR_HOST")
 }

--- a/examples/samples_test.go
+++ b/examples/samples_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -35,9 +36,25 @@ func TestRunSamples(t *testing.T) {
 			if !mainFile.IsDir() {
 				t.Run(item.Name(), func(t *testing.T) {
 					// Verify that we can run the sample.
-					ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+					timeout := time.Minute
+					if item.Name() == "emulator" {
+						timeout = 3 * time.Minute
+						if !isDockerAvailable() {
+							t.Skip("Docker is not available; skipping self-starting emulator test")
+						}
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
 					cmd := exec.CommandContext(ctx, "go", "run", "-race", ".")
 					cmd.Dir = item.Name()
+					if item.Name() == "emulator" {
+						var env []string
+						for _, envVar := range os.Environ() {
+							if !strings.HasPrefix(envVar, "SPANNER_EMULATOR_HOST=") {
+								env = append(env, envVar)
+							}
+						}
+						cmd.Env = env
+					}
 					var stderr bytes.Buffer
 					cmd.Stderr = &stderr
 					if err := cmd.Run(); err != nil {
@@ -49,4 +66,14 @@ func TestRunSamples(t *testing.T) {
 			}
 		}
 	}
+}
+
+func isDockerAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "info")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
 }

--- a/snippets/getting_started_guide_test.go
+++ b/snippets/getting_started_guide_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestSamples(t *testing.T) {
@@ -41,14 +43,23 @@ func TestSamples(t *testing.T) {
 	databaseID := "test-database"
 	databaseName := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
 
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" && !isDockerAvailable() {
+		t.Skip("Docker is not available; skipping self-starting emulator tests")
+	}
+
+	hasHostOriginally := os.Getenv("SPANNER_EMULATOR_HOST") != ""
 	emulator, err := startEmulator(projectID, instanceID, databaseID, adminpb.DatabaseDialect_GOOGLE_STANDARD_SQL)
 	if err != nil {
+		t.Fatalf("failed to start emulator: %v", err)
+	}
+	defer func() {
 		if emulator != nil {
 			_ = emulator.Terminate(context.Background())
 		}
-		t.Fatalf("failed to start emulator: %v", err)
-	}
-	defer func() { _ = emulator.Terminate(context.Background()) }()
+		if !hasHostOriginally {
+			_ = os.Unsetenv("SPANNER_EMULATOR_HOST")
+		}
+	}()
 
 	ctx := context.Background()
 	var b bytes.Buffer
@@ -78,14 +89,23 @@ func TestPostgreSQLSamples(t *testing.T) {
 	databaseID := "test-database"
 	databaseName := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
 
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" && !isDockerAvailable() {
+		t.Skip("Docker is not available; skipping self-starting PostgreSQL emulator tests")
+	}
+
+	hasHostOriginally := os.Getenv("SPANNER_EMULATOR_HOST") != ""
 	emulator, err := startEmulator(projectID, instanceID, databaseID, adminpb.DatabaseDialect_POSTGRESQL)
 	if err != nil {
+		t.Fatalf("failed to start emulator: %v", err)
+	}
+	defer func() {
 		if emulator != nil {
 			_ = emulator.Terminate(context.Background())
 		}
-		t.Fatalf("failed to start emulator: %v", err)
-	}
-	defer func() { _ = emulator.Terminate(context.Background()) }()
+		if !hasHostOriginally {
+			_ = os.Unsetenv("SPANNER_EMULATOR_HOST")
+		}
+	}()
 
 	ctx := context.Background()
 	var b bytes.Buffer
@@ -121,45 +141,59 @@ func testSample(t *testing.T, ctx context.Context, b *bytes.Buffer, databaseName
 
 func startEmulator(projectID, instanceID, databaseID string, dialect adminpb.DatabaseDialect) (testcontainers.Container, error) {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
-		AlwaysPullImage: true,
-		Image:           "gcr.io/cloud-spanner-emulator/emulator",
-		ExposedPorts:    []string{"9010/tcp"},
-		WaitingFor:      wait.ForListeningPort("9010/tcp"),
-		HostConfigModifier: func(hostConfig *container.HostConfig) {
-			hostConfig.AutoRemove = true
-		},
-	}
-	emulator, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		return emulator, fmt.Errorf("failed to start emulator: %v", err)
-	}
-	host, err := emulator.Host(ctx)
-	if err != nil {
-		return emulator, fmt.Errorf("failed to get host: %v", err)
-	}
-	mappedPort, err := emulator.MappedPort(ctx, "9010/tcp")
-	if err != nil {
-		return emulator, fmt.Errorf("failed to get mapped port: %v", err)
-	}
-	port := mappedPort.Port()
-	// Set the env var to connect to the emulator.
-	if err := os.Setenv("SPANNER_EMULATOR_HOST", fmt.Sprintf("%s:%v", host, port)); err != nil {
-		return emulator, fmt.Errorf("failed to set env var for emulator: %v", err)
+	var emulator testcontainers.Container
+	var err error
+	var success bool
+
+	defer func() {
+		if !success && emulator != nil {
+			_ = emulator.Terminate(ctx)
+			_ = os.Unsetenv("SPANNER_EMULATOR_HOST")
+		}
+	}()
+
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		req := testcontainers.ContainerRequest{
+			AlwaysPullImage: true,
+			Image:           "gcr.io/cloud-spanner-emulator/emulator",
+			ExposedPorts:    []string{"9010/tcp"},
+			WaitingFor:      wait.ForListeningPort("9010/tcp"),
+			HostConfigModifier: func(hostConfig *container.HostConfig) {
+				hostConfig.AutoRemove = true
+			},
+		}
+		emulator, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to start emulator: %v", err)
+		}
+		host, err := emulator.Host(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host: %v", err)
+		}
+		mappedPort, err := emulator.MappedPort(ctx, "9010/tcp")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get mapped port: %v", err)
+		}
+		port := mappedPort.Port()
+		// Set the env var to connect to the emulator.
+		if err := os.Setenv("SPANNER_EMULATOR_HOST", fmt.Sprintf("%s:%v", host, port)); err != nil {
+			return nil, fmt.Errorf("failed to set env var for emulator: %v", err)
+		}
 	}
 	if err := retryOnUnavailable(10, func() error {
 		return createInstance(projectID, instanceID)
 	}); err != nil {
-		return emulator, fmt.Errorf("failed to create instance: %v", err)
+		return nil, fmt.Errorf("failed to create instance: %v", err)
 	}
 	if err := retryOnUnavailable(10, func() error {
 		return createDatabase(projectID, instanceID, databaseID, dialect)
 	}); err != nil {
-		return emulator, fmt.Errorf("failed to create database: %v", err)
+		return nil, fmt.Errorf("failed to create database: %v", err)
 	}
+	success = true
 	return emulator, nil
 }
 
@@ -180,12 +214,23 @@ func retryOnUnavailable(maxAttempts int, f func() error) error {
 }
 
 func createInstance(projectID, instanceID string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	instanceAdmin, err := instance.NewInstanceAdminClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = instanceAdmin.Close() }()
+
+	inst, err := instanceAdmin.GetInstance(ctx, &instancepb.GetInstanceRequest{
+		Name: fmt.Sprintf("projects/%s/instances/%s", projectID, instanceID),
+	})
+	if err == nil && inst != nil {
+		return nil
+	}
+	if status.Code(err) != codes.NotFound {
+		return fmt.Errorf("failed to check if instance exists: %w", err)
+	}
 
 	op, err := instanceAdmin.CreateInstance(ctx, &instancepb.CreateInstanceRequest{
 		Parent:     fmt.Sprintf("projects/%s", projectID),
@@ -209,12 +254,16 @@ func createInstance(projectID, instanceID string) error {
 }
 
 func createDatabase(projectID, instanceID, databaseID string, dialect adminpb.DatabaseDialect) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	adminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = adminClient.Close() }()
+
+	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
+	_ = adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbPath})
 
 	var createStatement string
 	if dialect == adminpb.DatabaseDialect_POSTGRESQL {
@@ -234,4 +283,14 @@ func createDatabase(projectID, instanceID, databaseID string, dialect adminpb.Da
 		return err
 	}
 	return nil
+}
+
+func isDockerAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "info")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
- Swaps step order in GitHub Action workflows to checkout code before installing Go, which allows actions/setup-go to correctly restore/save the Go package cache.
- Adds cache-dependency-path configurations to support caching for all sub-modules (examples, snippets, benchmarks, and spannerlib).
- Adds a Spanner Emulator service to samples.yml and refactors samples and snippets test runners to check for SPANNER_EMULATOR_HOST. If set, they will bypass testcontainers/Docker startup and directly reuse the running emulator, performing safe database recreation.
- Isolates the "emulator" sample in samples_test.go to run without the host environment variable and with a 3-minute timeout to preserve CI coverage for the self-starting Docker flow.
- Adds a Docker availability check to gracefully skip tests requiring Docker on local developer machines when Docker is not installed or running.