### PR TITLE
chore(spannerlib): small optimizations for fetching multiple rows in .NET

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
@@ -209,11 +209,11 @@ public class StreamingRows : Rows
                 }
                 return null;
             }
-            foreach (var row in rowData.Data)
+            for (var i = 1; i < rowData.Data.Count; i++)
             {
-                _bufferedRows.Enqueue(row);
+                _bufferedRows.Enqueue(rowData.Data[i]);
             }
-            return _bufferedRows.Dequeue();
+            return rowData.Data[0];
         }
         catch (RpcException exception)
         {
@@ -261,11 +261,11 @@ public class StreamingRows : Rows
                 }
                 return null;
             }
-            foreach (var row in rowData.Data)
+            for (var i = 1; i < rowData.Data.Count; i++)
             {
-                _bufferedRows.Enqueue(row);
+                _bufferedRows.Enqueue(rowData.Data[i]);
             }
-            return _bufferedRows.Dequeue();
+            return rowData.Data[0];
         }
         catch (RpcException exception)
         {
@@ -350,7 +350,7 @@ public class StreamingRows : Rows
         {
             return result;
         }
-        _stream ??= _spanner.ContinueStreaming(SpannerConnection, Id, _batchSize);
+        _stream ??= _spanner.ContinueStreamingAsync(SpannerConnection, Id, _batchSize, cancellationToken);
         
         // Read data until we reach the next result set.
         await ReadUntilEndAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Small optimizations for fetching multiple rows in the SpannerLib .NET wrapper. Also changes the NextResultSetAsync method to call the ContinueStreamingAsync method.