### PR TITLE
chore: remove potential RPC calls in finalizer calls

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
@@ -115,9 +115,7 @@ public sealed class GrpcLibSpanner : ISpannerLib
             _clients[i] = new V1.SpannerLib.SpannerLibClient(_channels[i]);
         }
     }
-    
-    ~GrpcLibSpanner() => Dispose(false);
-    
+
     public void Dispose()
     {
         Dispose(true);
@@ -132,11 +130,17 @@ public sealed class GrpcLibSpanner : ISpannerLib
         }
         try
         {
-            foreach (var channel in _channels)
+            if (disposing)
             {
-                channel.Dispose();
+                if (_channels != null)
+                {
+                    foreach (var channel in _channels)
+                    {
+                        channel?.Dispose();
+                    }
+                }
+                _server?.Dispose();
             }
-            _server.Dispose();
         }
         finally
         {

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-server/Server.cs
@@ -253,8 +253,18 @@ public class Server : IDisposable
         }
         try
         {
-            Stop();
-            _process?.Dispose();
+            if (disposing)
+            {
+                try
+                {
+                    Stop();
+                }
+                catch (Exception)
+                {
+                    // Ignore exceptions during shutdown/dispose
+                }
+                _process?.Dispose();
+            }
         }
         finally
         {

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/ConnectionTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/ConnectionTests.cs
@@ -193,4 +193,43 @@ public class ConnectionTests : AbstractMockServerTests
             })));
         Assert.That(exception.Code, Is.EqualTo(Code.FailedPrecondition));
     }
+
+    private class TestLibObject : Google.Cloud.SpannerLib.AbstractLibObject
+    {
+        public bool CloseLibObjectCalled { get; private set; }
+
+        public TestLibObject(long id) : base(null!, id)
+        {
+        }
+
+        public void CallDispose(bool disposing)
+        {
+            Dispose(disposing);
+        }
+
+        protected override void CloseLibObject()
+        {
+            CloseLibObjectCalled = true;
+        }
+    }
+
+    [Test]
+    public void Finalizer_DoesNotCallCloseLibObject()
+    {
+        var testObj = new TestLibObject(id: 42);
+
+        testObj.CallDispose(disposing: false);
+
+        Assert.That(testObj.CloseLibObjectCalled, Is.False);
+    }
+
+    [Test]
+    public void Dispose_CallsCloseLibObject()
+    {
+        var testObj = new TestLibObject(id: 42);
+
+        testObj.CallDispose(disposing: true);
+
+        Assert.That(testObj.CloseLibObjectCalled, Is.True);
+    }
 }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/AbstractLibObject.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/AbstractLibObject.cs
@@ -42,10 +42,6 @@ public abstract class AbstractLibObject : IDisposable, IAsyncDisposable
         Id = id;
     } 
 
-    ~AbstractLibObject()
-    {
-        Dispose(false);
-    }
 
     protected void MarkDisposed()
     {
@@ -78,7 +74,7 @@ public abstract class AbstractLibObject : IDisposable, IAsyncDisposable
         }
         try
         {
-            if (Id > 0)
+            if (disposing && Id > 0)
             {
                 CloseLibObject();
             }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/spannerlib-dotnet.csproj
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/spannerlib-dotnet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -13,6 +13,12 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" Version="5.0.0.1" />
     <PackageReference Include="Google.Cloud.Spanner.V1" Version="5.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>spannerlib-dotnet-tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removes potential RPC calls in finalizers in the .NET wrapper.

This was previously implemented in https://github.com/googleapis/dotnet-spanner-entity-framework/pull/771, but it needs to be implemented here, as the code from this repository is synced to dotnet-spanner-entity-framework.