### PR TITLE
chore: prevent sync calls on async execution paths for stats

### DIFF
--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/GrpcLibSpanner.cs
@@ -370,6 +370,18 @@ public sealed class GrpcLibSpanner : ISpannerLib
         return TranslateException(() => Client.ResultSetStats(ToProto(rows)));
     }
 
+    public async Task<ResultSetStats?> StatsAsync(Rows rows, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await Client.ResultSetStatsAsync(ToProto(rows), cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RpcException exception)
+        {
+            throw SpannerException.ToSpannerException(exception);
+        }
+    }
+
     public ListValue? Next(Rows rows, int numRows, ISpannerLib.RowEncoding encoding)
     {
         var row = TranslateException(() =>Client.Next(new NextRequest

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-grpc-impl/StreamingRows.cs
@@ -60,6 +60,11 @@ public class StreamingRows : Rows
 
     protected override ResultSetStats? Stats => IsPositionedAtInMemResultSetWithAllData ? CurrentInMemResultSet.Stats : _stats;
 
+    public override Task<ResultSetStats?> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Stats);
+    }
+
     public override ResultSetMetadata? Metadata => IsPositionedAtInMemResultSet ? CurrentInMemResultSet.Metadata : _metadata;
 
     internal static StreamingRows Create(GrpcLibSpanner spanner, Connection connection, AsyncServerStreamingCall<RowData> stream, int batchSize)

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
@@ -1029,4 +1029,65 @@ public class RowsTests : AbstractMockServerTests
         var count = await rows.GetUpdateCountAsync();
         Assert.That(count, Is.EqualTo(updateCount));
     }
+
+    [Test]
+    public async Task TestNextAsyncPreFetchesStats([Values] LibType libType)
+    {
+        var updateCount = 5L;
+        var dml = "update my_table set value=1 where id in (1,2,3)";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(dml, StatementResult.CreateUpdateCount(updateCount));
+
+        await using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
+        await using var connection = pool.CreateConnection();
+        await using var rows = await connection.ExecuteAsync(new ExecuteSqlRequest { Sql = dml });
+
+        // Call NextAsync() which should return null immediately since DML has no rows.
+        var row = await rows.NextAsync();
+        Assert.That(row, Is.Null);
+
+        if (libType == LibType.Shared)
+        {
+            var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.That(statsLoadedField, Is.Not.Null);
+            Assert.That((bool)statsLoadedField.GetValue(rows)!, Is.True);
+        }
+        
+        Assert.That(rows.UpdateCount, Is.EqualTo(updateCount));
+    }
+
+    [Test]
+    public async Task TestNextAsyncPreFetchesStatsForQuery([Values] LibType libType)
+    {
+        var rowType = RandomResultSetGenerator.GenerateAllTypesRowType();
+        var results = RandomResultSetGenerator.Generate(rowType, 2);
+        var query = "select * from random";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(query, StatementResult.CreateQuery(results));
+
+        await using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
+        await using var connection = pool.CreateConnection();
+        await using var rows = await connection.ExecuteAsync(new ExecuteSqlRequest { Sql = query });
+
+        // Consume all rows.
+        Assert.That(await rows.NextAsync(), Is.Not.Null);
+        Assert.That(await rows.NextAsync(), Is.Not.Null);
+        
+        if (libType == LibType.Shared)
+        {
+            var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.That(statsLoadedField, Is.Not.Null);
+            Assert.That((bool)statsLoadedField.GetValue(rows)!, Is.False);
+        }
+
+        // Now call NextAsync() which reaches the end and returns null.
+        Assert.That(await rows.NextAsync(), Is.Null);
+
+        if (libType == LibType.Shared)
+        {
+            var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.That(statsLoadedField, Is.Not.Null);
+            Assert.That((bool)statsLoadedField.GetValue(rows)!, Is.True);
+        }
+        
+        Assert.That(rows.UpdateCount, Is.EqualTo(-1L));
+    }
 }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
@@ -1010,4 +1010,23 @@ public class RowsTests : AbstractMockServerTests
         hasNext = async ? Task.Run(async () => await rows.NextResultSetAsync()).Result : rows.NextResultSet();
         Assert.That(hasNext, Is.False);
     }
+
+    [Test]
+    public async Task TestStatsAndUpdateCountAsync([Values] LibType libType)
+    {
+        var updateCount = 5L;
+        var dml = "update my_table set value=1 where id in (1,2,3)";
+        Fixture.SpannerMock.AddOrUpdateStatementResult(dml, StatementResult.CreateUpdateCount(updateCount));
+
+        await using var pool = Pool.Create(SpannerLibDictionary[libType], ConnectionString);
+        await using var connection = pool.CreateConnection();
+        await using var rows = await connection.ExecuteAsync(new ExecuteSqlRequest { Sql = dml });
+
+        var stats = await rows.GetStatsAsync();
+        Assert.That(stats, Is.Not.Null);
+        Assert.That(stats.RowCountExact, Is.EqualTo(updateCount));
+
+        var count = await rows.GetUpdateCountAsync();
+        Assert.That(count, Is.EqualTo(updateCount));
+    }
 }

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet-tests/RowsTests.cs
@@ -1045,7 +1045,7 @@ public class RowsTests : AbstractMockServerTests
         var row = await rows.NextAsync();
         Assert.That(row, Is.Null);
 
-        if (libType == LibType.Shared)
+        if (rows.GetType() == typeof(Rows))
         {
             var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             Assert.That(statsLoadedField, Is.Not.Null);
@@ -1071,7 +1071,7 @@ public class RowsTests : AbstractMockServerTests
         Assert.That(await rows.NextAsync(), Is.Not.Null);
         Assert.That(await rows.NextAsync(), Is.Not.Null);
         
-        if (libType == LibType.Shared)
+        if (rows.GetType() == typeof(Rows))
         {
             var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             Assert.That(statsLoadedField, Is.Not.Null);
@@ -1081,7 +1081,7 @@ public class RowsTests : AbstractMockServerTests
         // Now call NextAsync() which reaches the end and returns null.
         Assert.That(await rows.NextAsync(), Is.Null);
 
-        if (libType == LibType.Shared)
+        if (rows.GetType() == typeof(Rows))
         {
             var statsLoadedField = typeof(Rows).GetField("_statsLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             Assert.That(statsLoadedField, Is.Not.Null);

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/ISpannerLib.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/ISpannerLib.cs
@@ -221,6 +221,16 @@ public interface ISpannerLib : IDisposable
     public ResultSetStats? Stats(Rows rows);
 
     /// <summary>
+    /// Returns the ResultSetStats of a Rows object asynchronously. This object contains the update count of a DML statement
+    /// that was executed. This method can only be called once all data rows in the Rows object have been returned.
+    /// </summary>
+    /// <param name="rows">The Rows object to get the stats for</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>The ResultSetStats for the given Rows object</returns>
+    public Task<ResultSetStats?> StatsAsync(Rows rows, CancellationToken cancellationToken = default) =>
+        Task.FromResult(Stats(rows));
+
+    /// <summary>
     /// Returns the next numRows data rows from the given Rows object. The data is encoded using the specified
     /// RowEncoding. The default is an encoded protobuf ListValue containing as many values as there are columns in the
     /// query result, multiplied by the number of rows that were returned.

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
@@ -136,7 +136,12 @@ public class Rows : AbstractLibObject
     /// <returns>The next data row or null if there are no more data</returns>
     public virtual async Task<ListValue?> NextAsync(CancellationToken cancellationToken = default)
     {
-        return await Spanner.NextAsync(this, 1, ISpannerLib.RowEncoding.Proto, cancellationToken).ConfigureAwait(false);
+        var res = await Spanner.NextAsync(this, 1, ISpannerLib.RowEncoding.Proto, cancellationToken).ConfigureAwait(false);
+        if (res == null && !_statsLoaded && !_stats.IsValueCreated)
+        {
+            await GetStatsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        return res;
     }
 
     /// <summary>

--- a/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
+++ b/spannerlib/wrappers/spannerlib-dotnet/spannerlib-dotnet/Rows.cs
@@ -33,34 +33,74 @@ public class Rows : AbstractLibObject
     public virtual ResultSetMetadata? Metadata => _metadata ??= Spanner.Metadata(this);
 
     private Lazy<ResultSetStats?> _stats;
+    private ResultSetStats? _loadedStats;
+    private bool _statsLoaded;
 
     /// <summary>
     /// The ResultSetStats of the SQL statement. This is only available once all data rows have been read.
     /// </summary>
-    protected virtual ResultSetStats? Stats => _stats.Value;
+    protected virtual ResultSetStats? Stats
+    {
+        get
+        {
+            if (!_statsLoaded)
+            {
+                _loadedStats = _stats.Value;
+                _statsLoaded = true;
+            }
+            return _loadedStats;
+        }
+    }
+
+    /// <summary>
+    /// Returns the ResultSetStats of this Rows object asynchronously.
+    /// </summary>
+    public virtual async Task<ResultSetStats?> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_statsLoaded)
+        {
+            return _loadedStats;
+        }
+        if (_stats.IsValueCreated)
+        {
+            _loadedStats = _stats.Value;
+            _statsLoaded = true;
+            return _loadedStats;
+        }
+        _loadedStats = await Spanner.StatsAsync(this, cancellationToken).ConfigureAwait(false);
+        _statsLoaded = true;
+        return _loadedStats;
+    }
+
+    private static long GetRowCount(ResultSetStats? stats)
+    {
+        if (stats == null)
+        {
+            return -1L;
+        }
+        if (stats.HasRowCountExact)
+        {
+            return stats.RowCountExact;
+        }
+        if (stats.HasRowCountLowerBound)
+        {
+            return stats.RowCountLowerBound;
+        }
+        return -1L;
+    }
 
     /// <summary>
     /// The update count of the SQL statement. This is only available once all data rows have been read.
     /// </summary>
-    public long UpdateCount
+    public long UpdateCount => GetRowCount(Stats);
+
+    /// <summary>
+    /// Gets the update count of the SQL statement asynchronously. This is only available once all data rows have been read.
+    /// </summary>
+    public async Task<long> GetUpdateCountAsync(CancellationToken cancellationToken = default)
     {
-        get
-        {
-            var stats = Stats;
-            if (stats == null)
-            {
-                return -1L;
-            }
-            if (stats.HasRowCountExact)
-            {
-                return stats.RowCountExact;
-            }
-            if (stats.HasRowCountLowerBound)
-            {
-                return stats.RowCountLowerBound;
-            }
-            return -1L;
-        }
+        var stats = await GetStatsAsync(cancellationToken).ConfigureAwait(false);
+        return GetRowCount(stats);
     }
     
     private bool _hasReadAllResults;
@@ -82,7 +122,7 @@ public class Rows : AbstractLibObject
     public virtual ListValue? Next()
     {
         var res = Spanner.Next(this, 1, ISpannerLib.RowEncoding.Proto);
-        if (res == null && !_stats.IsValueCreated)
+        if (res == null && !_statsLoaded && !_stats.IsValueCreated)
         {
             // initialize stats.
             _ = _stats.Value;
@@ -147,7 +187,7 @@ public class Rows : AbstractLibObject
         var hasUpdateCount = false;
         do
         {
-            var updateCount = UpdateCount;
+            var updateCount = await GetUpdateCountAsync(cancellationToken).ConfigureAwait(false);
             if (updateCount > -1)
             {
                 if (!hasUpdateCount)
@@ -196,6 +236,8 @@ public class Rows : AbstractLibObject
         }
         _metadata = metadata;
         _stats = new(() => Spanner.Stats(this));
+        _loadedStats = null;
+        _statsLoaded = false;
         return true;
     }
 


### PR DESCRIPTION
Prevents sync method calls in async execution paths in the .NET wrapper.

Previously implemented in https://github.com/googleapis/dotnet-spanner-entity-framework/pull/776, but this needs to be implemented in this repository, as the code from here is synced to dotnet-spanner-entity-framework.