### PR TITLE
feat: support PG connection properties in driver

### DIFF
--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -2025,3 +2025,69 @@ func getDialect(c *sql.Conn) (dialect databasepb.DatabaseDialect) {
 	})
 	return
 }
+
+func TestPostgreSQLCompatibilityGUCs(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnectionWithParamsAndDialect(t, "", databasepb.DatabaseDialect_POSTGRESQL)
+	defer teardown()
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer silentClose(conn)
+
+	// 1. Verify default values of the PG GUCs can be read
+	t.Run("DefaultValues", func(t *testing.T) {
+		verifyConnectionPropertyValue(t, conn, "application_name", "")
+		verifyConnectionPropertyValue(t, conn, "client_min_messages", "notice")
+		verifyConnectionPropertyValue(t, conn, "client_encoding", "UTF8")
+		verifyConnectionPropertyValue(t, conn, "timezone", "UTC")
+		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "serializable")
+		verifyConnectionPropertyValue(t, conn, "server_version_num", "140001")
+		verifyConnectionPropertyValue(t, conn, "server_version", "14.1")
+	})
+
+	// 2. Verify read-write variables can be set
+	t.Run("SetReadWrite", func(t *testing.T) {
+		setConnectionPropertyValue(t, conn, "application_name", "'my-awesome-app'")
+		verifyConnectionPropertyValue(t, conn, "application_name", "my-awesome-app")
+
+		setConnectionPropertyValue(t, conn, "timezone", "'Asia/Kolkata'")
+		verifyConnectionPropertyValue(t, conn, "timezone", "Asia/Kolkata")
+
+		setConnectionPropertyValue(t, conn, "client_min_messages", "'warning'")
+		verifyConnectionPropertyValue(t, conn, "client_min_messages", "warning")
+
+		setConnectionPropertyValue(t, conn, "default_transaction_isolation", "'serializable'")
+		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "serializable")
+	})
+
+	// 3. Verify read-only or invalid variables fail to set
+	t.Run("SetReadOnlyOrInvalidFails", func(t *testing.T) {
+		verifySetFails(t, conn, "default_transaction_isolation", "'read committed'")
+		verifySetFails(t, conn, "server_version_num", "'150000'")
+	})
+}
+
+func TestPostgreSQLCompatibilityGUCs_GoogleSQL(t *testing.T) {
+	t.Parallel()
+
+	db, _, teardown := setupTestDBConnectionWithParamsAndDialect(t, "", databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL)
+	defer teardown()
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer silentClose(conn)
+
+	// Verify that setting/showing PG GUCs fails on GoogleSQL connection
+	verifySetFails(t, conn, "application_name", "'my-awesome-app'")
+	verifySetFails(t, conn, "timezone", "'Asia/Kolkata'")
+	verifyShowFails[string](t, conn, "application_name")
+	verifyShowFails[string](t, conn, "timezone")
+}

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -2063,6 +2063,9 @@ func TestPostgreSQLCompatibilityGUCs(t *testing.T) {
 
 		setConnectionPropertyValue(t, conn, "default_transaction_isolation", "'serializable'")
 		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "serializable")
+
+		setConnectionPropertyValue(t, conn, "default_transaction_isolation", "'repeatable_read'")
+		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "repeatable_read")
 	})
 
 	// 3. Verify read-only or invalid variables fail to set

--- a/conn_with_mockserver_test.go
+++ b/conn_with_mockserver_test.go
@@ -2065,7 +2065,10 @@ func TestPostgreSQLCompatibilityGUCs(t *testing.T) {
 		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "serializable")
 
 		setConnectionPropertyValue(t, conn, "default_transaction_isolation", "'repeatable_read'")
-		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "repeatable_read")
+		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "repeatable read")
+
+		setConnectionPropertyValue(t, conn, "default_transaction_isolation", "'repeatable read'")
+		verifyConnectionPropertyValue(t, conn, "default_transaction_isolation", "repeatable read")
 	})
 
 	// 3. Verify read-only or invalid variables fail to set

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -748,6 +748,45 @@ var propertyDatabaseDialect = createReadOnlyConnectionProperty(
 	connectionstate.ContextUser,
 )
 
+// PostgreSQL compatibility connection properties (no-op or defaults for client library setup queries)
+var postgresConnectionProperties map[string]connectionstate.ConnectionProperty
+
+func init() {
+	postgresProperties := map[string]connectionstate.ConnectionProperty{}
+
+	addPostgresProp := func(name, description, defaultValue string, hasDefaultValue bool, converter func(string) (string, error)) {
+		prop := connectionstate.CreateConnectionProperty(name, description, defaultValue, hasDefaultValue, nil, connectionstate.ContextUser, converter)
+		postgresProperties[prop.Key()] = prop
+	}
+
+	addReadOnlyPostgresProp := func(name, description, defaultValue string) {
+		converter := connectionstate.CreateReadOnlyConverter[string](name)
+		addPostgresProp(name, description, defaultValue, true, converter)
+	}
+
+	addPostgresProp("application_name", "Sets the application name to be reported in statistics and logs. This property is currently a no-op.", "", false, connectionstate.ConvertString)
+	addPostgresProp("client_min_messages", "Controls which message levels are sent to the client. This property is currently a no-op.", "notice", false, connectionstate.ConvertString)
+	addPostgresProp("client_encoding", "Sets the client-side character set encoding. Spanner only supports UTF-8 encoding.", "UTF8", false, connectionstate.ConvertString)
+	addPostgresProp("timezone", "Sets the default time zone for the connection. This property is currently a no-op.", "UTC", false, connectionstate.ConvertString)
+
+	addPostgresProp("default_transaction_isolation", "The default transaction isolation level. Spanner PostgreSQL dialect only supports serializable isolation.", "serializable", true, func(val string) (string, error) {
+		if strings.EqualFold(val, "serializable") {
+			return "serializable", nil
+		}
+		return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable isolation")
+	})
+	addReadOnlyPostgresProp("server_version_num", "The PostgreSQL server version number represented as an integer (e.g. 140001).", "140001")
+	addReadOnlyPostgresProp("server_version", "The PostgreSQL server version string (e.g. 14.1).", "14.1")
+
+	postgresConnectionProperties = make(map[string]connectionstate.ConnectionProperty, len(connectionProperties)+len(postgresProperties))
+	for k, v := range connectionProperties {
+		postgresConnectionProperties[k] = v
+	}
+	for k, v := range postgresProperties {
+		postgresConnectionProperties[k] = v
+	}
+}
+
 func createReadOnlyConnectionProperty[T comparable](name, description string, defaultValue T, hasDefaultValue bool, validValues []T, context connectionstate.Context) *connectionstate.TypedConnectionProperty[T] {
 	converter := connectionstate.CreateReadOnlyConverter[T](name)
 	return createConnectionProperty(name, description, defaultValue, hasDefaultValue, validValues, context, converter)
@@ -772,7 +811,14 @@ func createInitialConnectionState(connectionStateType connectionstate.Type, init
 }
 
 func createInitialConnectionStateWithDialect(dialect databasepb.DatabaseDialect, connectionStateType connectionstate.Type, initialValues map[string]connectionstate.ConnectionPropertyValue) *connectionstate.ConnectionState {
-	state, _ := connectionstate.NewConnectionState(connectionStateType, connectionProperties, initialValues)
+	var props map[string]connectionstate.ConnectionProperty
+	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
+		props = postgresConnectionProperties
+	} else {
+		props = connectionProperties
+	}
+
+	state, _ := connectionstate.NewConnectionState(connectionStateType, props, initialValues)
 	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
 		state.AddAlias("transaction_isolation", "isolation_level", true /* readOnly */)
 		if val := propertyIsolationLevel.GetValueOrDefault(state); val == sql.LevelDefault {

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -769,14 +769,19 @@ func init() {
 	addPostgresProp("client_encoding", "Sets the client-side character set encoding. Spanner only supports UTF-8 encoding.", "UTF8", false, connectionstate.ConvertString)
 	addPostgresProp("timezone", "Sets the default time zone for the connection. This property is currently a no-op.", "UTC", false, connectionstate.ConvertString)
 
-	addPostgresProp("default_transaction_isolation", "The default transaction isolation level. Spanner PostgreSQL dialect supports serializable and repeatable_read isolation.", "serializable", true, func(val string) (string, error) {
-		if strings.EqualFold(val, "serializable") {
+	addPostgresProp("default_transaction_isolation", "The default transaction isolation level. Spanner PostgreSQL dialect supports serializable and repeatable read isolation. Default is serializable.", "serializable", true, func(val string) (string, error) {
+		level, err := parseIsolationLevel(val)
+		if err != nil {
+			return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable or repeatable read isolation: %v", err)
+		}
+		switch level {
+		case sql.LevelSerializable:
 			return "serializable", nil
+		case sql.LevelRepeatableRead:
+			return "repeatable read", nil
+		default:
+			return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable or repeatable read isolation")
 		}
-		if strings.EqualFold(val, "repeatable_read") {
-			return "repeatable_read", nil
-		}
-		return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable or repeatable_read isolation")
 	})
 	addReadOnlyPostgresProp("server_version_num", "The PostgreSQL server version number represented as an integer (e.g. 140001).", "140001")
 	addReadOnlyPostgresProp("server_version", "The PostgreSQL server version string (e.g. 14.1).", "14.1")

--- a/connection_properties.go
+++ b/connection_properties.go
@@ -769,11 +769,14 @@ func init() {
 	addPostgresProp("client_encoding", "Sets the client-side character set encoding. Spanner only supports UTF-8 encoding.", "UTF8", false, connectionstate.ConvertString)
 	addPostgresProp("timezone", "Sets the default time zone for the connection. This property is currently a no-op.", "UTC", false, connectionstate.ConvertString)
 
-	addPostgresProp("default_transaction_isolation", "The default transaction isolation level. Spanner PostgreSQL dialect only supports serializable isolation.", "serializable", true, func(val string) (string, error) {
+	addPostgresProp("default_transaction_isolation", "The default transaction isolation level. Spanner PostgreSQL dialect supports serializable and repeatable_read isolation.", "serializable", true, func(val string) (string, error) {
 		if strings.EqualFold(val, "serializable") {
 			return "serializable", nil
 		}
-		return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable isolation")
+		if strings.EqualFold(val, "repeatable_read") {
+			return "repeatable_read", nil
+		}
+		return "", status.Errorf(codes.InvalidArgument, "Spanner PostgreSQL only supports serializable or repeatable_read isolation")
 	})
 	addReadOnlyPostgresProp("server_version_num", "The PostgreSQL server version number represented as an integer (e.g. 140001).", "140001")
 	addReadOnlyPostgresProp("server_version", "The PostgreSQL server version string (e.g. 14.1).", "14.1")

--- a/spannerlib/api/rows.go
+++ b/spannerlib/api/rows.go
@@ -296,14 +296,12 @@ func (rows *rows) nextBatch(ctx context.Context, numRows int32) ([]*structpb.Lis
 				_ = rows.backend.Close()
 				return nil, err
 			}
+			_ = rows.readStats(ctx)
 			if !rows.isMulti {
-				_ = rows.readStats(ctx)
 				if rows.cancel != nil {
 					rows.cancel()
 				}
 				_ = rows.backend.Close()
-			} else {
-				_ = rows.readStats(ctx)
 			}
 			break
 		}
@@ -398,7 +396,7 @@ func (rows *rows) readMetadata(ctx context.Context) error {
 func (rows *rows) readStats(ctx context.Context) error {
 	rows.stats = &spannerpb.ResultSetStats{}
 	if !rows.backend.NextResultSet() {
-		return status.Error(codes.Internal, "stats results not found")
+		return nil
 	}
 	if rows.backend.Next() {
 		if err := rows.backend.Scan(&rows.stats); err != nil {

--- a/spannerlib/api/rows.go
+++ b/spannerlib/api/rows.go
@@ -296,12 +296,14 @@ func (rows *rows) nextBatch(ctx context.Context, numRows int32) ([]*structpb.Lis
 				_ = rows.backend.Close()
 				return nil, err
 			}
-			_ = rows.readStats(ctx)
 			if !rows.isMulti {
+				_ = rows.readStats(ctx)
 				if rows.cancel != nil {
 					rows.cancel()
 				}
 				_ = rows.backend.Close()
+			} else {
+				_ = rows.readStats(ctx)
 			}
 			break
 		}
@@ -396,7 +398,7 @@ func (rows *rows) readMetadata(ctx context.Context) error {
 func (rows *rows) readStats(ctx context.Context) error {
 	rows.stats = &spannerpb.ResultSetStats{}
 	if !rows.backend.NextResultSet() {
-		return nil
+		return status.Error(codes.Internal, "stats results not found")
 	}
 	if rows.backend.Next() {
 		if err := rows.backend.Scan(&rows.stats); err != nil {

--- a/statements.go
+++ b/statements.go
@@ -95,6 +95,12 @@ func (s *executableShowStatement) queryContext(ctx context.Context, c *conn, opt
 			isolationStr = strings.ToLower(isolationStr)
 		}
 		it, err = createStringIterator(col, isolationStr)
+	case time.Duration:
+		stringVal := ""
+		if hasValue {
+			stringVal = val.String()
+		}
+		it, err = createStringIterator(col, stringVal)
 	default:
 		stringVal := ""
 		if hasValue {


### PR DESCRIPTION
### Summary
Adds support for PostgreSQL-specific GUC configuration properties (`application_name`, `timezone`, `client_min_messages`, `client_encoding`, `default_transaction_isolation`, `server_version`, and `server_version_num`). These defaults and no-op properties enable standard PostgreSQL drivers to connect and execute initial setup queries seamlessly.

### Changes
* **PostgreSQL GUC Properties**: Defined no-op PostgreSQL compatibility properties.
* **Dialect Isolation**: Segregated PostgreSQL properties from GoogleSQL connections so GoogleSQL connection states remain clean.
* **Performance Optimization**: Pre-computed `postgresConnectionProperties` during package `init()` to avoid map allocations and copying on every connection setup.
* **Test Coverage**: Added mock server unit tests in `conn_with_mockserver_test.go` verifying read/write behavior, read-only validation, and dialect restriction.
