### PR TITLE
fix(spannerlib): gracefully handle missing stats for single statements

### DIFF
--- a/spannerlib/api/rows.go
+++ b/spannerlib/api/rows.go
@@ -296,14 +296,12 @@ func (rows *rows) nextBatch(ctx context.Context, numRows int32) ([]*structpb.Lis
 				_ = rows.backend.Close()
 				return nil, err
 			}
+			_ = rows.readStats(ctx)
 			if !rows.isMulti {
-				_ = rows.readStats(ctx)
 				if rows.cancel != nil {
 					rows.cancel()
 				}
 				_ = rows.backend.Close()
-			} else {
-				_ = rows.readStats(ctx)
 			}
 			break
 		}
@@ -396,14 +394,22 @@ func (rows *rows) readMetadata(ctx context.Context) error {
 }
 
 func (rows *rows) readStats(ctx context.Context) error {
-	rows.stats = &spannerpb.ResultSetStats{}
+	stats := &spannerpb.ResultSetStats{}
 	if !rows.backend.NextResultSet() {
-		return status.Error(codes.Internal, "stats results not found")
-	}
-	if rows.backend.Next() {
-		if err := rows.backend.Scan(&rows.stats); err != nil {
+		if err := rows.backend.Err(); err != nil {
 			return err
 		}
+		rows.stats = stats
+		return nil
+	}
+	if rows.backend.Next() {
+		if err := rows.backend.Scan(&stats); err != nil {
+			return err
+		}
+		if stats == nil {
+			stats = &spannerpb.ResultSetStats{}
+		}
+		rows.stats = stats
 	} else {
 		if err := rows.backend.Err(); err != nil {
 			return err

--- a/spannerlib/api/rows_test.go
+++ b/spannerlib/api/rows_test.go
@@ -929,3 +929,115 @@ func TestExecuteWithBooleanStringParams(t *testing.T) {
 		t.Errorf("receivedReq p1 boolean value mismatch\nGot:  %v\nWant: %v", g, w)
 	}
 }
+
+func TestSingleStatementQuery_NormalExecution(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+
+	sqlText := "SELECT 1"
+	_ = server.TestSpanner.PutStatementResult(sqlText, &testutil.StatementResult{
+		Type:      testutil.StatementResultResultSet,
+		ResultSet: testutil.CreateSelect1ResultSet(),
+	})
+
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+	poolId, err := CreatePool(ctx, "test", dsn)
+	if err != nil {
+		t.Fatalf("CreatePool returned unexpected error: %v", err)
+	}
+	defer func() { _ = ClosePool(ctx, poolId) }()
+
+	connId, err := CreateConnection(ctx, poolId)
+	if err != nil {
+		t.Fatalf("CreateConnection returned unexpected error: %v", err)
+	}
+	defer func() { _ = CloseConnection(ctx, poolId, connId) }()
+
+	rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{
+		Sql: sqlText,
+	})
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	defer func() { _ = CloseRows(ctx, poolId, connId, rowsId) }()
+
+	// Iterate through the results until EOF
+	count := 0
+	for {
+		batch, err := Next(ctx, poolId, connId, rowsId, 1)
+		if err != nil {
+			t.Fatalf("Failed to fetch next row batch: %v", err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		count += len(batch)
+	}
+
+	if g, w := count, 1; g != w {
+		t.Fatalf("row count mismatch\nGot:  %d\nWant: %d", g, w)
+	}
+
+	// Verify that reaching EOF did not trigger a stats error when obtaining stats
+	stats, err := ResultSetStats(ctx, poolId, connId, rowsId)
+	if err != nil {
+		t.Fatalf("Expected no error after iterating rows, but got: %v", err)
+	}
+	if stats == nil {
+		t.Fatal("Expected non-nil stats after iterating rows")
+	}
+}
+
+func TestReadStats_NoStatsResultSet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, teardown := setupMockServer(t)
+	defer teardown()
+
+	sqlText := "SELECT 1"
+	_ = server.TestSpanner.PutStatementResult(sqlText, &testutil.StatementResult{
+		Type:      testutil.StatementResultResultSet,
+		ResultSet: testutil.CreateSelect1ResultSet(),
+	})
+
+	dsn := fmt.Sprintf("%s/projects/p/instances/i/databases/d?useplaintext=true", server.Address)
+	poolId, err := CreatePool(ctx, "test", dsn)
+	if err != nil {
+		t.Fatalf("CreatePool returned unexpected error: %v", err)
+	}
+	defer func() { _ = ClosePool(ctx, poolId) }()
+
+	connId, err := CreateConnection(ctx, poolId)
+	if err != nil {
+		t.Fatalf("CreateConnection returned unexpected error: %v", err)
+	}
+	defer func() { _ = CloseConnection(ctx, poolId, connId) }()
+
+	rowsId, err := Execute(ctx, poolId, connId, &spannerpb.ExecuteSqlRequest{
+		Sql: sqlText,
+	})
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	defer func() { _ = CloseRows(ctx, poolId, connId, rowsId) }()
+
+	p, _ := pools.Load(poolId)
+	pool := p.(*Pool)
+	c, _ := pool.connections.Load(connId)
+	conn := c.(*Connection)
+	r, _ := conn.results.Load(rowsId)
+	res := r.(*rows)
+
+	// Advance backend past the last result set so backend.NextResultSet() returns false.
+	for res.backend.NextResultSet() {
+	}
+
+	err = res.readStats(ctx)
+	if err != nil {
+		t.Fatalf("readStats returned unexpected error when NextResultSet is false: %v", err)
+	}
+}


### PR DESCRIPTION
In `readStats`, normal (non-profiled) single-statement queries do not 
return a trailing stats result set. The previous implementation returned 
a "stats results not found" error, which disrupted normal execution. 
This fix returns `nil` when there is no error or return `rows.backend.Err()`, allowing the EOF auto-close logic to 
complete successfully without phantom errors.